### PR TITLE
fix(#27): add collision debug toggle with F3 key

### DIFF
--- a/packages/client/src/game/scenes/BootScene.ts
+++ b/packages/client/src/game/scenes/BootScene.ts
@@ -16,24 +16,37 @@ export class BootScene extends Phaser.Scene {
     graphics.generateTexture('tile-placeholder', 32, 32);
 
     graphics.clear();
-    graphics.fillStyle(0x00ff00);
-    graphics.fillRect(0, 0, 24, 24);
-    graphics.generateTexture('player-human', 24, 24);
-
-    graphics.clear();
-    graphics.fillStyle(0xff0000);
-    graphics.fillRect(0, 0, 24, 24);
-    graphics.generateTexture('player-agent', 24, 24);
-
-    graphics.clear();
-    graphics.fillStyle(0x0000ff);
-    graphics.fillRect(0, 0, 24, 24);
-    graphics.generateTexture('player-object', 24, 24);
-
-    graphics.clear();
     graphics.fillStyle(0xffff00);
     graphics.fillRect(0, 0, 32, 32);
     graphics.generateTexture('selection-marker', 32, 32);
+
+    const humanGraphics = this.make.graphics({ x: 0, y: 0 });
+    humanGraphics.fillStyle(0x4488ff);
+    humanGraphics.fillCircle(16, 16, 14);
+    humanGraphics.fillStyle(0xffffff);
+    humanGraphics.fillCircle(12, 12, 4);
+    humanGraphics.fillCircle(20, 12, 4);
+    humanGraphics.fillStyle(0x000000);
+    humanGraphics.fillCircle(12, 12, 2);
+    humanGraphics.fillCircle(20, 12, 2);
+    humanGraphics.generateTexture('player-human', 32, 32);
+
+    const agentGraphics = this.make.graphics({ x: 0, y: 0 });
+    agentGraphics.fillStyle(0x44ff88);
+    agentGraphics.fillRect(4, 8, 24, 20);
+    agentGraphics.fillStyle(0x000000);
+    agentGraphics.fillRect(10, 12, 4, 4);
+    agentGraphics.fillRect(18, 12, 4, 4);
+    agentGraphics.fillRect(14, 2, 4, 8);
+    agentGraphics.fillCircle(16, 2, 3);
+    agentGraphics.generateTexture('player-agent', 32, 32);
+
+    const objectGraphics = this.make.graphics({ x: 0, y: 0 });
+    objectGraphics.fillStyle(0x8b4513);
+    objectGraphics.fillRect(4, 4, 24, 24);
+    objectGraphics.lineStyle(2, 0x654321);
+    objectGraphics.strokeRect(4, 4, 24, 24);
+    objectGraphics.generateTexture('player-object', 32, 32);
 
     this.scene.start('GameScene');
   }


### PR DESCRIPTION
## Summary
- Added collision debug visualization toggle using F3 key
- Shows red semi-transparent overlay on blocked tiles
- Displays "DEBUG: Collision ON (F3)" indicator when active
- Does not affect gameplay mechanics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 엔티티 위에 표시되는 채팅 버블 추가
  * F3 키로 토글 가능한 충돌 영역 시각화 기능 추가

* **시각적 개선**
  * 플레이어 그래픽 업그레이드: 절차 생성 텍스처로 더욱 상세한 비주얼 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->