### PR TITLE
fix(#30): add integration tests with real server

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,6 +24,7 @@
     "@colyseus/ws-transport": "^0.15.0",
     "@openclawworld/shared": "workspace:*",
     "colyseus": "^0.15.0",
+    "cors": "^2.8.6",
     "dotenv": "^16.4.0",
     "express": "^4.18.0",
     "express-rate-limit": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       colyseus:
         specifier: ^0.15.0
         version: 0.15.57(@colyseus/schema@2.0.37)(express@4.22.1)
+      cors:
+        specifier: ^2.8.6
+        version: 2.8.6
       dotenv:
         specifier: ^16.4.0
         version: 16.6.1
@@ -1061,6 +1064,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1632,6 +1639,10 @@ packages:
 
   oauth-sign@0.9.0:
     resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -2905,6 +2916,11 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3602,6 +3618,8 @@ snapshots:
       path-key: 4.0.0
 
   oauth-sign@0.9.0: {}
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 

--- a/tests/integration/movement.test.ts
+++ b/tests/integration/movement.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { OpenClawWorldClient } from '@openclawworld/plugin';
+import { startTestServer, getTestApiKey, type TestServer } from './test-server.js';
+
+describe('Integration: Scenario C - Movement', () => {
+  let server: TestServer;
+  let client: OpenClawWorldClient;
+
+  beforeAll(async () => {
+    server = await startTestServer();
+    client = new OpenClawWorldClient({
+      baseUrl: `${server.baseUrl}/aic/v0.1`,
+      apiKey: getTestApiKey(),
+      retryMaxAttempts: 1,
+      retryBaseDelayMs: 100,
+    });
+  }, 60000);
+
+  afterAll(async () => {
+    await server.shutdown();
+  }, 30000);
+
+  describe('Step 1: Agent requests movement', () => {
+    it('sends moveTo request and receives response', async () => {
+      const txId = `tx_${Date.now()}_move`;
+
+      const result = await client.moveTo({
+        agentId: 'agent_test_move',
+        roomId: 'lobby',
+        txId,
+        dest: { tx: 10, ty: 10 },
+      });
+
+      expect(result.status).toBe('ok');
+      if (result.status === 'ok') {
+        expect(result.data.txId).toBe(txId);
+        expect(typeof result.data.applied).toBe('boolean');
+        expect(['accepted', 'rejected', 'no_op']).toContain(result.data.result);
+      }
+    });
+
+    it('handles movement to different destinations', async () => {
+      const destinations = [
+        { tx: 5, ty: 5 },
+        { tx: 15, ty: 15 },
+        { tx: 20, ty: 10 },
+      ];
+
+      for (const dest of destinations) {
+        const txId = `tx_${Date.now()}_move_${dest.tx}_${dest.ty}`;
+        const result = await client.moveTo({
+          agentId: 'agent_test_move',
+          roomId: 'lobby',
+          txId,
+          dest,
+        });
+
+        expect(result.status).toBe('ok');
+        if (result.status === 'ok') {
+          expect(result.data.txId).toBe(txId);
+          expect(typeof result.data.applied).toBe('boolean');
+        }
+      }
+    });
+  });
+
+  describe('Step 2: Verify position after movement', () => {
+    it('observes environment to check position', async () => {
+      const result = await client.observe({
+        agentId: 'agent_test_move',
+        roomId: 'lobby',
+        radius: 100,
+        detail: 'full',
+      });
+
+      expect(result.status).toBe('ok');
+      if (result.status === 'ok') {
+        expect(result.data.self).toBeDefined();
+        expect(result.data.self.tile).toBeDefined();
+        expect(typeof result.data.self.tile!.tx).toBe('number');
+        expect(typeof result.data.self.tile!.ty).toBe('number');
+        expect(result.data.self.pos).toBeDefined();
+        expect(typeof result.data.self.pos.x).toBe('number');
+        expect(typeof result.data.self.pos.y).toBe('number');
+      }
+    });
+  });
+
+  describe('Step 3: Poll for movement events', () => {
+    it('polls events for movement-related events', async () => {
+      const result = await client.pollEvents({
+        agentId: 'agent_test_move',
+        roomId: 'lobby',
+        sinceCursor: '0',
+      });
+
+      expect(result.status).toBe('ok');
+      if (result.status === 'ok') {
+        expect(Array.isArray(result.data.events)).toBe(true);
+        expect(typeof result.data.nextCursor).toBe('string');
+      }
+    });
+  });
+
+  describe('Full Scenario Flow', () => {
+    it('completes movement scenario against real server', async () => {
+      const initialObserve = await client.observe({
+        agentId: 'agent_test_move',
+        roomId: 'lobby',
+        radius: 100,
+        detail: 'full',
+      });
+
+      expect(initialObserve.status).toBe('ok');
+
+      const txId = `tx_${Date.now()}_scenario`;
+      const moveResult = await client.moveTo({
+        agentId: 'agent_test_move',
+        roomId: 'lobby',
+        txId,
+        dest: { tx: 12, ty: 12 },
+      });
+
+      expect(moveResult.status).toBe('ok');
+      if (moveResult.status === 'ok') {
+        expect(moveResult.data.txId).toBe(txId);
+        expect(typeof moveResult.data.applied).toBe('boolean');
+      }
+
+      const finalObserve = await client.observe({
+        agentId: 'agent_test_move',
+        roomId: 'lobby',
+        radius: 100,
+        detail: 'full',
+      });
+
+      expect(finalObserve.status).toBe('ok');
+      if (finalObserve.status === 'ok') {
+        expect(finalObserve.data.self).toBeDefined();
+        expect(finalObserve.data.self.tile).toBeDefined();
+      }
+    });
+
+    it('handles idempotent movement requests', async () => {
+      const txId = `tx_${Date.now()}_idempotent`;
+
+      const result1 = await client.moveTo({
+        agentId: 'agent_test_move',
+        roomId: 'lobby',
+        txId,
+        dest: { tx: 8, ty: 8 },
+      });
+
+      const result2 = await client.moveTo({
+        agentId: 'agent_test_move',
+        roomId: 'lobby',
+        txId,
+        dest: { tx: 8, ty: 8 },
+      });
+
+      expect(result1.status).toBe('ok');
+      expect(result2.status).toBe('ok');
+
+      if (result1.status === 'ok' && result2.status === 'ok') {
+        expect(result1.data.txId).toBe(txId);
+        expect(result2.data.txId).toBe(txId);
+      }
+    });
+  });
+});

--- a/tests/integration/proximity-chat.test.ts
+++ b/tests/integration/proximity-chat.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { OpenClawWorldClient } from '@openclawworld/plugin';
+import { startTestServer, getTestApiKey, type TestServer } from './test-server.js';
+
+describe('Integration: Scenario B - Proximity Chat', () => {
+  let server: TestServer;
+  let agentClient: OpenClawWorldClient;
+
+  beforeAll(async () => {
+    server = await startTestServer();
+    agentClient = new OpenClawWorldClient({
+      baseUrl: `${server.baseUrl}/aic/v0.1`,
+      apiKey: getTestApiKey(),
+      retryMaxAttempts: 1,
+      retryBaseDelayMs: 100,
+    });
+  }, 60000);
+
+  afterAll(async () => {
+    await server.shutdown();
+  }, 30000);
+
+  describe('Step 1: Poll for events', () => {
+    it('polls events successfully', async () => {
+      const result = await agentClient.pollEvents({
+        agentId: 'agent_test_chat',
+        roomId: 'lobby',
+        sinceCursor: '0',
+      });
+
+      expect(result.status).toBe('ok');
+      if (result.status === 'ok') {
+        expect(Array.isArray(result.data.events)).toBe(true);
+        expect(typeof result.data.nextCursor).toBe('string');
+        expect(result.data.serverTsMs).toBeGreaterThan(0);
+      }
+    });
+
+    it('receives empty or valid events array', async () => {
+      const result = await agentClient.pollEvents({
+        agentId: 'agent_test_chat',
+        roomId: 'lobby',
+        sinceCursor: '0',
+      });
+
+      expect(result.status).toBe('ok');
+      if (result.status === 'ok') {
+        expect(Array.isArray(result.data.events)).toBe(true);
+        result.data.events.forEach(event => {
+          expect(event).toHaveProperty('cursor');
+          expect(event).toHaveProperty('type');
+          expect(event).toHaveProperty('roomId');
+          expect(event).toHaveProperty('tsMs');
+          expect(event).toHaveProperty('payload');
+        });
+      }
+    });
+  });
+
+  describe('Step 2: Agent can send chat messages', () => {
+    it('sends chat message successfully', async () => {
+      const txId = `tx_${Date.now()}_chat`;
+
+      const result = await agentClient.chatSend({
+        agentId: 'agent_test_chat',
+        roomId: 'lobby',
+        txId,
+        channel: 'proximity',
+        message: 'Hello from integration test!',
+      });
+
+      expect(result.status).toBe('ok');
+      if (result.status === 'ok') {
+        expect(result.data.applied).toBe(true);
+        expect(result.data.txId).toBe(txId);
+        expect(result.data.chatMessageId).toBeDefined();
+      }
+    });
+
+    it('handles invalid room gracefully', async () => {
+      const txId = `tx_${Date.now()}_invalid`;
+
+      const result = await agentClient.chatSend({
+        agentId: 'agent_test_chat',
+        roomId: 'nonexistent_room',
+        txId,
+        channel: 'proximity',
+        message: 'Test message',
+      });
+
+      expect(result.status).toBeDefined();
+    });
+  });
+
+  describe('Full Scenario Flow', () => {
+    it('completes proximity chat scenario against real server', async () => {
+      const initialPoll = await agentClient.pollEvents({
+        agentId: 'agent_test_chat',
+        roomId: 'lobby',
+        sinceCursor: '0',
+      });
+
+      expect(initialPoll.status).toBe('ok');
+
+      const txId = `tx_${Date.now()}_scenario`;
+      const sendResult = await agentClient.chatSend({
+        agentId: 'agent_test_chat',
+        roomId: 'lobby',
+        txId,
+        channel: 'proximity',
+        message: 'Integration test message',
+      });
+
+      expect(sendResult.status).toBe('ok');
+      if (sendResult.status === 'ok') {
+        expect(sendResult.data.applied).toBe(true);
+      }
+
+      if (initialPoll.status === 'ok') {
+        const followUpPoll = await agentClient.pollEvents({
+          agentId: 'agent_test_chat',
+          roomId: 'lobby',
+          sinceCursor: initialPoll.data.nextCursor,
+        });
+
+        expect(followUpPoll.status).toBe('ok');
+        if (followUpPoll.status === 'ok') {
+          expect(Array.isArray(followUpPoll.data.events)).toBe(true);
+        }
+      }
+    });
+  });
+});

--- a/tests/integration/sign-reading.test.ts
+++ b/tests/integration/sign-reading.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { OpenClawWorldClient } from '@openclawworld/plugin';
+import { startTestServer, getTestApiKey, type TestServer } from './test-server.js';
+
+describe('Integration: Scenario A - Sign Reading', () => {
+  let server: TestServer;
+  let client: OpenClawWorldClient;
+
+  beforeAll(async () => {
+    server = await startTestServer();
+    client = new OpenClawWorldClient({
+      baseUrl: `${server.baseUrl}/aic/v0.1`,
+      apiKey: getTestApiKey(),
+      retryMaxAttempts: 1,
+      retryBaseDelayMs: 100,
+    });
+  }, 60000);
+
+  afterAll(async () => {
+    await server.shutdown();
+  }, 30000);
+
+  describe('Step 1: Agent observes and finds nearby sign', () => {
+    it('observes environment and finds objects', async () => {
+      const result = await client.observe({
+        agentId: 'agent_test_sign',
+        roomId: 'lobby',
+        radius: 100,
+        detail: 'full',
+      });
+
+      expect(result.status).toBe('ok');
+      if (result.status === 'ok') {
+        expect(result.data.self).toBeDefined();
+        expect(result.data.room).toBeDefined();
+        expect(Array.isArray(result.data.nearby)).toBe(true);
+      }
+    });
+
+    it('receives valid room information', async () => {
+      const result = await client.observe({
+        agentId: 'agent_test_sign',
+        roomId: 'lobby',
+        radius: 100,
+        detail: 'full',
+      });
+
+      expect(result.status).toBe('ok');
+      if (result.status === 'ok') {
+        expect(result.data.room.roomId).toBe('lobby');
+        expect(result.data.room.mapId).toBeDefined();
+        expect(typeof result.data.room.tickRate).toBe('number');
+        expect(result.data.serverTsMs).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('Step 2: Agent attempts to interact', () => {
+    it('can send interact request for read action', async () => {
+      const txId = `tx_${Date.now()}_read`;
+
+      const result = await client.interact({
+        agentId: 'agent_test_sign',
+        roomId: 'lobby',
+        txId,
+        targetId: 'obj_sign_test',
+        action: 'read',
+      });
+
+      expect(result.status).toBeDefined();
+      if (result.status === 'ok') {
+        expect(typeof result.data.applied).toBe('boolean');
+        expect(result.data.txId).toBe(txId);
+      }
+    });
+
+    it('handles non-existent object gracefully', async () => {
+      const txId = `tx_${Date.now()}_nonexistent`;
+
+      const result = await client.interact({
+        agentId: 'agent_test_sign',
+        roomId: 'lobby',
+        txId,
+        targetId: 'obj_does_not_exist',
+        action: 'read',
+      });
+
+      expect(result.status).toBeDefined();
+      if (result.status === 'ok') {
+        expect(result.data.applied).toBe(false);
+      } else {
+        expect(result.error).toBeDefined();
+      }
+    });
+  });
+
+  describe('Full Scenario Flow', () => {
+    it('completes sign reading scenario against real server', async () => {
+      const observeResult = await client.observe({
+        agentId: 'agent_test_sign',
+        roomId: 'lobby',
+        radius: 100,
+        detail: 'full',
+      });
+
+      expect(observeResult.status).toBe('ok');
+
+      if (observeResult.status === 'ok') {
+        const sign = observeResult.data.nearby.find(n => n.affords?.some(a => a.action === 'read'));
+
+        if (sign) {
+          const txId = `tx_${Date.now()}_scenario`;
+          const interactResult = await client.interact({
+            agentId: 'agent_test_sign',
+            roomId: 'lobby',
+            txId,
+            targetId: sign.entity.id,
+            action: 'read',
+          });
+
+          expect(interactResult.status).toBe('ok');
+          if (interactResult.status === 'ok') {
+            expect(interactResult.data.txId).toBe(txId);
+            expect(typeof interactResult.data.applied).toBe('boolean');
+          }
+        }
+      }
+    });
+  });
+});

--- a/tests/integration/test-server.ts
+++ b/tests/integration/test-server.ts
@@ -1,0 +1,110 @@
+import { spawn, type ChildProcess } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export interface TestServer {
+  process: ChildProcess;
+  port: number;
+  baseUrl: string;
+  shutdown: () => Promise<void>;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForServer(url: string, timeout = 30000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      // Expected - server not ready yet, continue polling
+    }
+    await sleep(500);
+  }
+  throw new Error(`Server did not start within ${timeout}ms`);
+}
+
+export async function startTestServer(): Promise<TestServer> {
+  const port = 10000 + Math.floor(Math.random() * 55000);
+  const baseUrl = `http://localhost:${port}`;
+
+  const serverDir = resolve(__dirname, '../../packages/server');
+
+  const serverProcess = spawn('tsx', ['watch', 'src/index.ts'], {
+    cwd: serverDir,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      NODE_ENV: 'test',
+    },
+    stdio: 'pipe',
+  });
+
+  let stdout = '';
+  let stderr = '';
+
+  serverProcess.stdout?.on('data', (data: Buffer) => {
+    stdout += data.toString();
+  });
+
+  serverProcess.stderr?.on('data', (data: Buffer) => {
+    stderr += data.toString();
+  });
+
+  try {
+    await waitForServer(`${baseUrl}/health`);
+  } catch (error) {
+    serverProcess.kill('SIGTERM');
+    throw new Error(
+      `Failed to start test server on port ${port}. ` +
+        `Stdout: ${stdout}\nStderr: ${stderr}\nError: ${error}`
+    );
+  }
+
+  const shutdown = async (): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        serverProcess.kill('SIGKILL');
+        reject(new Error('Server shutdown timeout'));
+      }, 10000);
+
+      serverProcess.on('close', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      serverProcess.on('error', err => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+
+      serverProcess.kill('SIGTERM');
+    });
+  };
+
+  return {
+    process: serverProcess,
+    port,
+    baseUrl,
+    shutdown,
+  };
+}
+
+export async function withTestServer<T>(fn: (server: TestServer) => Promise<T>): Promise<T> {
+  const server = await startTestServer();
+  try {
+    return await fn(server);
+  } finally {
+    await server.shutdown();
+  }
+}
+
+export function getTestApiKey(): string {
+  return 'test-api-key-integration';
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.{test,spec}.{ts,js}', 'packages/**/*.{test,spec}.{ts,js}'],
-    exclude: ['**/node_modules/**', '**/dist/**', '**/build/**'],
+    exclude: ['**/node_modules/**', '**/dist/**', '**/build/**', 'tests/integration/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'html'],


### PR DESCRIPTION
Resolves #30. Adds integration tests for all 3 scenarios. Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 이동(Scenario C), 근접 채팅(Scenario B), 표지판 읽기 등 통합 테스트 스위트 추가 및 다양한 시나리오(이동, 관찰, 이벤트 폴링, 채팅 전송/수신, 상호작용) 검증
  * 테스트 전후 서버 라이프사이클과 idempotency, 중복 요청 처리 등을 포함한 엔드투엔드 흐름 검증

* **Chores**
  * 테스트 실행을 위한 서버 설정 관련 의존성 추가 (개발/테스트 인프라 지원)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->