### PR TITLE
fix(aic): make register endpoint unauthenticated

### DIFF
--- a/packages/server/src/aic/router.ts
+++ b/packages/server/src/aic/router.ts
@@ -28,6 +28,15 @@ import { handleRegister } from './handlers/register.js';
 
 const router: Router = Router();
 
+// Register endpoint is UNAUTHENTICATED - agents call this to get their first token
+router.post(
+  '/register',
+  interactRateLimiter,
+  validateRequest(RegisterRequestSchema),
+  handleRegister
+);
+
+// All routes below require authentication
 router.use(authMiddleware);
 
 router.post('/observe', observeRateLimiter, validateRequest(ObserveRequestSchema), handleObserve);
@@ -60,13 +69,6 @@ router.post(
   pollEventsRateLimiter,
   validateRequest(PollEventsRequestSchema),
   handlePollEvents
-);
-
-router.post(
-  '/register',
-  interactRateLimiter, // Use interact rate limiter (10 req/min) for registration
-  validateRequest(RegisterRequestSchema),
-  handleRegister
 );
 
 export default router;


### PR DESCRIPTION
## Summary

Resolves #22 - Agent Registration Endpoint Missing

**Root Cause:** The `/register` endpoint was defined AFTER `router.use(authMiddleware)`, requiring agents to have a token before they could get their first token.

## Changes

- Moved `/register` route before `authMiddleware` application
- Added security comments explaining the route ordering constraint
- Removed duplicate route definition

## Testing

- [x] All 207 tests pass (including 17 register.test.ts tests)
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Build succeeds

## API Usage

After this fix, AI agents can register via:

```bash
curl -X POST http://localhost:2567/aic/v0.1/register \
  -H "Content-Type: application/json" \
  -d '{"name": "MyAgent", "roomId": "default"}'
```

Response:
```json
{
  "status": "ok",
  "data": {
    "agentId": "agt_0001",
    "roomId": "default",
    "sessionToken": "tok_..."
  }
}
```

The returned `sessionToken` is then used for all subsequent authenticated requests.