### PR TITLE
feat(client): add SVG entity sprites

### DIFF
--- a/packages/client/public/assets/sprites/player-agent.svg
+++ b/packages/client/public/assets/sprites/player-agent.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect x="6" y="6" width="20" height="16" rx="3" fill="#44FF88"/>
+  <rect x="8" y="22" width="16" height="8" rx="2" fill="#33CC66"/>
+  <rect x="10" y="10" width="4" height="4" fill="#000"/>
+  <rect x="18" y="10" width="4" height="4" fill="#000"/>
+  <rect x="11" y="11" width="2" height="2" fill="#0FF"/>
+  <rect x="19" y="11" width="2" height="2" fill="#0FF"/>
+  <rect x="12" y="0" width="3" height="8" fill="#888"/>
+  <rect x="17" y="0" width="3" height="8" fill="#888"/>
+  <circle cx="13.5" cy="0" r="2" fill="#F00"/>
+  <circle cx="18.5" cy="0" r="2" fill="#F00"/>
+  <rect x="11" y="17" width="10" height="2" fill="#333"/>
+</svg>

--- a/packages/client/public/assets/sprites/player-human.svg
+++ b/packages/client/public/assets/sprites/player-human.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <circle cx="16" cy="8" r="6" fill="#FFD0A0"/>
+  <rect x="8" y="14" width="16" height="14" rx="2" fill="#4488FF"/>
+  <rect x="6" y="14" width="4" height="10" rx="2" fill="#4488FF"/>
+  <rect x="22" y="14" width="4" height="10" rx="2" fill="#4488FF"/>
+  <rect x="10" y="26" width="4" height="6" fill="#2244AA"/>
+  <rect x="18" y="26" width="4" height="6" fill="#2244AA"/>
+  <circle cx="13" cy="7" r="1.5" fill="#333"/>
+  <circle cx="19" cy="7" r="1.5" fill="#333"/>
+  <path d="M13 11 Q16 13 19 11" stroke="#333" stroke-width="1" fill="none"/>
+</svg>

--- a/packages/client/public/assets/sprites/player-object.svg
+++ b/packages/client/public/assets/sprites/player-object.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect x="2" y="6" width="28" height="24" rx="2" fill="#8B4513"/>
+  <rect x="4" y="8" width="24" height="20" fill="#A0522D"/>
+  <line x1="4" y1="18" x2="28" y2="18" stroke="#654321" stroke-width="2"/>
+  <line x1="16" y1="8" x2="16" y2="28" stroke="#654321" stroke-width="2"/>
+  <rect x="12" y="2" width="8" height="6" rx="1" fill="#CD853F"/>
+  <rect x="14" y="4" width="4" height="2" fill="#8B4513"/>
+  <circle cx="8" cy="12" r="2" fill="#654321"/>
+  <circle cx="24" cy="12" r="2" fill="#654321"/>
+  <circle cx="8" cy="24" r="2" fill="#654321"/>
+  <circle cx="24" cy="24" r="2" fill="#654321"/>
+</svg>

--- a/packages/client/src/game/scenes/BootScene.ts
+++ b/packages/client/src/game/scenes/BootScene.ts
@@ -7,6 +7,10 @@ export class BootScene extends Phaser.Scene {
 
   preload() {
     this.load.tilemapTiledJSON('lobby', 'assets/maps/lobby.json');
+
+    this.load.svg('player-human', 'assets/sprites/player-human.svg', { width: 32, height: 32 });
+    this.load.svg('player-agent', 'assets/sprites/player-agent.svg', { width: 32, height: 32 });
+    this.load.svg('player-object', 'assets/sprites/player-object.svg', { width: 32, height: 32 });
   }
 
   create() {
@@ -19,34 +23,6 @@ export class BootScene extends Phaser.Scene {
     graphics.fillStyle(0xffff00);
     graphics.fillRect(0, 0, 32, 32);
     graphics.generateTexture('selection-marker', 32, 32);
-
-    const humanGraphics = this.make.graphics({ x: 0, y: 0 });
-    humanGraphics.fillStyle(0x4488ff);
-    humanGraphics.fillCircle(16, 16, 14);
-    humanGraphics.fillStyle(0xffffff);
-    humanGraphics.fillCircle(12, 12, 4);
-    humanGraphics.fillCircle(20, 12, 4);
-    humanGraphics.fillStyle(0x000000);
-    humanGraphics.fillCircle(12, 12, 2);
-    humanGraphics.fillCircle(20, 12, 2);
-    humanGraphics.generateTexture('player-human', 32, 32);
-
-    const agentGraphics = this.make.graphics({ x: 0, y: 0 });
-    agentGraphics.fillStyle(0x44ff88);
-    agentGraphics.fillRect(4, 8, 24, 20);
-    agentGraphics.fillStyle(0x000000);
-    agentGraphics.fillRect(10, 12, 4, 4);
-    agentGraphics.fillRect(18, 12, 4, 4);
-    agentGraphics.fillRect(14, 2, 4, 8);
-    agentGraphics.fillCircle(16, 2, 3);
-    agentGraphics.generateTexture('player-agent', 32, 32);
-
-    const objectGraphics = this.make.graphics({ x: 0, y: 0 });
-    objectGraphics.fillStyle(0x8b4513);
-    objectGraphics.fillRect(4, 4, 24, 24);
-    objectGraphics.lineStyle(2, 0x654321);
-    objectGraphics.strokeRect(4, 4, 24, 24);
-    objectGraphics.generateTexture('player-object', 32, 32);
 
     this.scene.start('GameScene');
   }


### PR DESCRIPTION
## Summary

Resolves #33 - Entity Sprites Missing (Colored Shapes Only)

Replace procedurally generated colored shapes with actual SVG sprite images for all entity types.

## Changes

### New Sprite Assets
- `player-human.svg` - Character with skin tone face, blue shirt, dark pants
- `player-agent.svg` - Robot with green body, antenna with red lights, cyan digital eyes
- `player-object.svg` - Wooden crate with handle and corner nail details

### Code Changes
- Updated `BootScene.ts` to load SVG sprites via `this.load.svg()`
- Removed procedural texture generation for entity sprites
- Kept placeholder textures for tiles and selection marker

## Visual Preview

| Entity Type | Description |
|-------------|-------------|
| Human | Person icon with face, body, arms, legs |
| Agent | Robot icon with antenna, body, screen eyes |
| Object | Crate icon with wood texture and details |

## Testing

- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] All 207 tests pass
- [x] Build succeeds

## Notes

- SVGs are vector-based and scale cleanly
- Each sprite is 32x32 pixels to match tile size
- Existing sprite texture keys (`player-human`, `player-agent`, `player-object`) are preserved for compatibility