### PR TITLE
test: add edge case tests for zone boundary detection

### DIFF
--- a/tests/unit/zone-system-64x64.test.ts
+++ b/tests/unit/zone-system-64x64.test.ts
@@ -378,4 +378,66 @@ describe('ZoneSystem - 64x64 Grid-Town Layout (2048x2048 pixels)', () => {
       expect(zoneIds).toContain('lake');
     });
   });
+
+  describe('zone boundary edge cases', () => {
+    describe('lake/lobby boundary at x=192', () => {
+      // Lake: (64,64) to (192,512) - ends at x=191 (exclusive)
+      // Lobby: (192,64) to (576,448) - starts at x=192 (inclusive)
+
+      it('detects lake at x=191 (last pixel before lobby)', () => {
+        expect(zoneSystem.detectZone(191, 100)).toBe('lake');
+      });
+
+      it('detects lobby at x=192 (first pixel of lobby)', () => {
+        expect(zoneSystem.detectZone(192, 100)).toBe('lobby');
+      });
+
+      it('detects lake at x=64 (left edge of lake)', () => {
+        expect(zoneSystem.detectZone(64, 100)).toBe('lake');
+      });
+    });
+
+    describe('central-park/arcade boundary at x=1408', () => {
+      // Central-park: (640,512) to (1408,1152) - ends at x=1407
+      // Arcade: (1408,512) to (1984,1024) - starts at x=1408
+
+      it('detects central-park at x=1407 (last pixel before arcade)', () => {
+        expect(zoneSystem.detectZone(1407, 700)).toBe('central-park');
+      });
+
+      it('detects arcade at x=1408 (first pixel of arcade)', () => {
+        expect(zoneSystem.detectZone(1408, 700)).toBe('arcade');
+      });
+    });
+
+    describe('lounge-cafe/plaza boundary at x=1216', () => {
+      // Lounge-cafe: (576,1216) to (1216,1664) - ends at x=1215
+      // Plaza: (1216,1216) to (1728,1728) - starts at x=1216
+
+      it('detects lounge-cafe at x=1215 (last pixel before plaza)', () => {
+        expect(zoneSystem.detectZone(1215, 1300)).toBe('lounge-cafe');
+      });
+
+      it('detects plaza at x=1216 (first pixel of plaza)', () => {
+        expect(zoneSystem.detectZone(1216, 1300)).toBe('plaza');
+      });
+    });
+
+    describe('vertical boundaries', () => {
+      // Lake: y=64 to y=512 (ends at y=511)
+      // Meeting: y=896 to y=1472 (starts at y=896)
+
+      it('detects lake at y=511 (last pixel before gap)', () => {
+        expect(zoneSystem.detectZone(100, 511)).toBe('lake');
+      });
+
+      it('detects null in gap between lake and meeting', () => {
+        expect(zoneSystem.detectZone(100, 600)).toBeNull();
+      });
+
+      it('detects meeting at y=896 (first pixel of meeting)', () => {
+        expect(zoneSystem.detectZone(100, 896)).toBe('meeting');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Resolves #85

## Changes
- Added boundary edge case tests for adjacent zones
- Tests verify exact pixel boundaries are correctly detected:
  - lake/lobby boundary at x=192
  - central-park/arcade boundary at x=1408
  - lounge-cafe/plaza boundary at x=1216
  - vertical boundaries (lake/meeting gap)

## Test Coverage
- Validates zone bounds are correctly exclusive on right/bottom edges
- Ensures no gaps or overlaps at zone boundaries

## Testing
- [x] All new tests pass
- [x] All existing tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **테스트**
  * Grid-Town 64x64 레이아웃의 구역 감지 경계 케이스를 검증하는 단위 테스트 추가. 여러 구역 경계의 엣지 케이스 및 수직 경계 검증을 포함합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->