### PR TITLE
fix: align resident-agent-loop with current AIC API schema

### DIFF
--- a/scripts/resident-agent-loop.ts
+++ b/scripts/resident-agent-loop.ts
@@ -724,11 +724,13 @@ class ResidentAgent {
       if (result.status === 'ok') {
         if (result.data.nearby) {
           for (const entity of result.data.nearby) {
-            this.state.observedEntities.set(entity.id, {
-              entityId: entity.id,
-              position: { x: entity.pos?.x ?? 0, y: entity.pos?.y ?? 0 },
-              timestamp: Date.now(),
-            });
+            if (entity.pos?.x != null && entity.pos?.y != null) {
+              this.state.observedEntities.set(entity.id, {
+                entityId: entity.id,
+                position: { x: entity.pos.x, y: entity.pos.y },
+                timestamp: Date.now(),
+              });
+            }
           }
         }
         this.state.position = {
@@ -809,7 +811,13 @@ class ResidentAgent {
       const result = await response.json();
       if (result.status === 'ok' && result.data.messages) {
         this.state.chatHistory = result.data.messages.map(
-          (m: { fromEntityId: string; fromName: string; message: string; channel: string; tsMs: number }) => ({
+          (m: {
+            fromEntityId: string;
+            fromName: string;
+            message: string;
+            channel: string;
+            tsMs: number;
+          }) => ({
             from: m.fromEntityId,
             message: m.message,
             timestamp: m.tsMs,


### PR DESCRIPTION
## Summary
- Fix `resident-agent-loop.ts` to match the current AIC API schema, which was causing all agent operations to fail with 400 errors

## Changes
- **observe**: Add missing `detail` field (required by API, was returning 400 without it)
- **observe response**: Fix field mapping (`data.entities` → `data.nearby`, `entity.entityId` → `entity.id`, `entity.x/y` → `entity.pos.x/y`, `data.self.x/y` → `data.self.pos.x/y`)
- **chatObserve**: Replace `limit` with `windowSec` (required field per OpenAPI spec)
- **chatObserve response**: Fix field mapping (`from/text/serverTsMs` → `fromEntityId/message/tsMs`)

## Testing
- Ran `pnpm resident-agent-loop -- --agents 5 --dry-run` — all agents operate without errors
- Ran real mode — successfully created GitHub issue [#97](https://github.com/Two-Weeks-Team/openClawWorld/issues/97) (Chat message mismatch detection)
- Duplicate detection working correctly (subsequent identical issues skipped)

## Before (all 400 errors)
```
[agt_xxx] Error: Observe failed: 400
  → Invalid input: expected string for /detail
```

## After (clean operation)
```
✓ Registered explorer: agt_xxx
✓ Registered worker: agt_xxx
✅ 5 agents initialized
🚀 Starting agent behaviors...
--- Cycle 1 ---
  No issues detected
--- Cycle 2 ---
📝 Creating issue: [Resident-Agent][Chat] Chat message mismatch between agents
✅ Created issue: https://github.com/Two-Weeks-Team/openClawWorld/issues/97
```