### PR TITLE
refactor: remove z.lazy() by reordering schema declarations

### DIFF
--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -201,13 +201,57 @@ export const RoomInfoSchema = z.object({
   tickRate: z.int().min(1).max(60),
 });
 
+export const ZoneIdSchema = z.enum([
+  'lobby',
+  'office',
+  'central-park',
+  'arcade',
+  'meeting',
+  'lounge-cafe',
+  'plaza',
+  'lake',
+]);
+
+export const EntranceDirectionSchema = z.enum(['north', 'south', 'east', 'west']);
+
+export const BuildingEntranceSchema = z.object({
+  id: z.string().min(1).max(128),
+  name: z.string().min(1).max(128),
+  position: Vec2Schema,
+  size: z.object({ width: z.number(), height: z.number() }),
+  zone: ZoneIdSchema,
+  direction: EntranceDirectionSchema,
+  connectsTo: ZoneIdSchema,
+});
+
+export const ZoneInfoSchema = z.object({
+  id: ZoneIdSchema,
+  bounds: z.object({
+    x: z.number(),
+    y: z.number(),
+    width: z.number(),
+    height: z.number(),
+  }),
+  entrances: z.array(BuildingEntranceSchema),
+});
+
+export const MapMetadataSchema = z.object({
+  currentZone: ZoneIdSchema.nullable(),
+  zones: z.array(ZoneInfoSchema),
+  mapSize: z.object({
+    width: z.number().int().min(1),
+    height: z.number().int().min(1),
+    tileSize: z.number().int().min(1),
+  }),
+});
+
 export const ObserveResponseDataSchema = z.object({
   self: EntityBaseSchema,
   nearby: z.array(ObservedEntitySchema).max(500),
   facilities: z.array(ObservedFacilitySchema).max(100),
   serverTsMs: TsMsSchema,
   room: RoomInfoSchema,
-  mapMetadata: z.lazy(() => MapMetadataSchema).optional(),
+  mapMetadata: MapMetadataSchema.optional(),
 });
 
 export const MoveToResultSchema = z.enum(['accepted', 'rejected', 'no_op']);
@@ -429,50 +473,6 @@ export const StatusResponseDataSchema = z.object({
 // ============================================================================
 
 export const OrgRoleSchema = z.enum(['owner', 'admin', 'member', 'guest']);
-
-export const ZoneIdSchema = z.enum([
-  'lobby',
-  'office',
-  'central-park',
-  'arcade',
-  'meeting',
-  'lounge-cafe',
-  'plaza',
-  'lake',
-]);
-
-export const EntranceDirectionSchema = z.enum(['north', 'south', 'east', 'west']);
-
-export const BuildingEntranceSchema = z.object({
-  id: z.string().min(1).max(128),
-  name: z.string().min(1).max(128),
-  position: Vec2Schema,
-  size: z.object({ width: z.number(), height: z.number() }),
-  zone: ZoneIdSchema,
-  direction: EntranceDirectionSchema,
-  connectsTo: ZoneIdSchema,
-});
-
-export const ZoneInfoSchema = z.object({
-  id: ZoneIdSchema,
-  bounds: z.object({
-    x: z.number(),
-    y: z.number(),
-    width: z.number(),
-    height: z.number(),
-  }),
-  entrances: z.array(BuildingEntranceSchema),
-});
-
-export const MapMetadataSchema = z.object({
-  currentZone: ZoneIdSchema.nullable(),
-  zones: z.array(ZoneInfoSchema),
-  mapSize: z.object({
-    width: z.number().int().min(1),
-    height: z.number().int().min(1),
-    tileSize: z.number().int().min(1),
-  }),
-});
 
 export const MeetingStatusSchema = z.enum(['scheduled', 'in_progress', 'ended', 'cancelled']);
 


### PR DESCRIPTION
## Summary
Resolves #82

## Changes
- Reordered schema declarations in `packages/shared/src/schemas.ts`
- Moved `MapMetadataSchema` and its dependencies (`ZoneIdSchema`, `EntranceDirectionSchema`, `BuildingEntranceSchema`, `ZoneInfoSchema`) before `ObserveResponseDataSchema`
- Replaced `z.lazy(() => MapMetadataSchema)` with direct `MapMetadataSchema` reference

## Why
`z.lazy()` was only needed because `MapMetadataSchema` was defined after `ObserveResponseDataSchema` which referenced it. By reordering the declarations, the lazy evaluation is no longer necessary, simplifying the code.

## Testing
- [x] Type checking passes
- [x] All 962 tests pass
- [x] No API changes - only declaration order changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 맵 관련 스키마 정의를 정리하여 공개 API를 간소화했습니다.
  * 존(zone), 입구 방향, 건물 입구 정보 등의 스키마를 공개 API로 추가했습니다.
  * 맵 메타데이터 처리 방식을 개선하여 API 응답 구조를 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->