### PR TITLE
feat(world): migrate to 16x16 native tile system

### DIFF
--- a/packages/client/public/assets/maps/tileset.json
+++ b/packages/client/public/assets/maps/tileset.json
@@ -1,10 +1,10 @@
 {
   "name": "tileset",
-  "tilewidth": 32,
-  "tileheight": 32,
+  "tilewidth": 16,
+  "tileheight": 16,
   "tilecount": 32,
   "columns": 8,
   "image": "tileset.svg",
-  "imagewidth": 256,
-  "imageheight": 128
+  "imagewidth": 128,
+  "imageheight": 64
 }

--- a/packages/client/src/game/scenes/GameScene.ts
+++ b/packages/client/src/game/scenes/GameScene.ts
@@ -108,7 +108,7 @@ export class GameScene extends Phaser.Scene {
     this.skillBar = new SkillBar(this);
     this.castBar = new CastBar(this);
 
-    this.tileInterpreter = new TileInterpreter(32);
+    this.tileInterpreter = new TileInterpreter(16);
     this.clientCollision = new ClientCollisionSystem();
     this.initializeWorldGrid();
 
@@ -144,7 +144,7 @@ export class GameScene extends Phaser.Scene {
         collisionData
       );
 
-      this.clientCollision.setWorldGrid(worldGrid, 32);
+      this.clientCollision.setWorldGrid(worldGrid, 16);
     }
   }
 
@@ -305,7 +305,7 @@ export class GameScene extends Phaser.Scene {
   }
 
   private findEntityAtPosition(x: number, y: number): string | undefined {
-    const clickRadius = 32;
+    const clickRadius = 16;
     let closestId: string | undefined;
     let closestDist = Infinity;
 
@@ -335,7 +335,7 @@ export class GameScene extends Phaser.Scene {
 
     this.marker = this.add.graphics();
     this.marker.lineStyle(2, 0xffff00, 1);
-    this.marker.strokeRect(0, 0, 32, 32);
+    this.marker.strokeRect(0, 0, 16, 16);
     this.marker.setVisible(false);
     this.marker.setDepth(100);
 
@@ -425,7 +425,7 @@ export class GameScene extends Phaser.Scene {
           break;
       }
 
-      const sprite = this.add.sprite(obj.x + 16, obj.y + 16, texture);
+      const sprite = this.add.sprite(obj.x + 8, obj.y + 8, texture);
       sprite.setDepth(obj.y);
 
       if (objType === 'portal') {
@@ -460,7 +460,7 @@ export class GameScene extends Phaser.Scene {
       const pointerTileY = this.map.worldToTileY(worldPoint.y);
 
       if (pointerTileX !== null && pointerTileY !== null) {
-        this.marker?.setPosition(pointerTileX * 32, pointerTileY * 32);
+        this.marker?.setPosition(pointerTileX * 16, pointerTileY * 16);
         this.marker?.setVisible(true);
 
         gameClient.moveTo(pointerTileX, pointerTileY);
@@ -629,8 +629,8 @@ export class GameScene extends Phaser.Scene {
 
   private drawDebugMapBoundary(): void {
     if (!this.map || !this.zoneDebug) return;
-    const mapWidth = this.map.width * 32;
-    const mapHeight = this.map.height * 32;
+    const mapWidth = this.map.width * 16;
+    const mapHeight = this.map.height * 16;
 
     this.zoneDebug.lineStyle(3, DEBUG_COLORS.mapBorder, 0.8);
     this.zoneDebug.strokeRect(0, 0, mapWidth, mapHeight);
@@ -685,9 +685,9 @@ export class GameScene extends Phaser.Scene {
         if (tile.index > 0) {
           blockedCount++;
           this.collisionDebug?.fillStyle(DEBUG_COLORS.collision, 0.4);
-          this.collisionDebug?.fillRect(x * 32, y * 32, 32, 32);
+          this.collisionDebug?.fillRect(x * 16, y * 16, 16, 16);
           this.collisionDebug?.lineStyle(1, DEBUG_COLORS.collision, 0.6);
-          this.collisionDebug?.strokeRect(x * 32, y * 32, 32, 32);
+          this.collisionDebug?.strokeRect(x * 16, y * 16, 16, 16);
         }
       });
     });
@@ -1230,8 +1230,8 @@ export class GameScene extends Phaser.Scene {
       const objType = this.getObjectProperty(obj, 'type') as string;
       if (!objType || objType === 'spawn' || objType === 'decoration') return;
 
-      const objCenterX = obj.x + 16;
-      const objCenterY = obj.y + 16;
+      const objCenterX = obj.x + 8;
+      const objCenterY = obj.y + 8;
       const distance = Phaser.Math.Distance.Between(playerX, playerY, objCenterX, objCenterY);
 
       if (distance < interactionRadius && distance < closestDistance) {

--- a/packages/client/src/systems/CollisionSystem.ts
+++ b/packages/client/src/systems/CollisionSystem.ts
@@ -4,9 +4,9 @@ export class ClientCollisionSystem {
   private worldGrid: WorldGrid | null = null;
   private width: number = 0;
   private height: number = 0;
-  private tileSize: number = 32;
+  private tileSize: number = 16;
 
-  setWorldGrid(grid: WorldGrid, tileSize: number = 32): void {
+  setWorldGrid(grid: WorldGrid, tileSize: number = 16): void {
     this.worldGrid = grid;
     this.tileSize = tileSize;
     this.height = grid.length;

--- a/packages/client/src/ui/Minimap.ts
+++ b/packages/client/src/ui/Minimap.ts
@@ -83,39 +83,39 @@ export class Minimap {
     for (let y = 0; y < 3; y++) {
       this.zoneGraphics.fillRect(
         offsetX,
-        offsetY + y * 32 * scaleY,
+        offsetY + y * 16 * scaleY,
         this.config.width - 8,
-        32 * scaleY
+        16 * scaleY
       );
     }
     for (let y = 3; y < 20; y++) {
-      this.zoneGraphics.fillRect(offsetX, offsetY + y * 32 * scaleY, 5 * 32 * scaleX, 32 * scaleY);
+      this.zoneGraphics.fillRect(offsetX, offsetY + y * 16 * scaleY, 5 * 16 * scaleX, 16 * scaleY);
     }
 
     this.zoneGraphics.fillStyle(EXTRA_COLORS.road, 0.6);
     this.zoneGraphics.fillRect(
-      offsetX + 17 * 32 * scaleX,
-      offsetY + 12 * 32 * scaleY,
-      23 * 32 * scaleX,
-      4 * 32 * scaleY
+      offsetX + 17 * 16 * scaleX,
+      offsetY + 12 * 16 * scaleY,
+      23 * 16 * scaleX,
+      4 * 16 * scaleY
     );
     this.zoneGraphics.fillRect(
-      offsetX + 17 * 32 * scaleX,
-      offsetY + 16 * 32 * scaleY,
-      4 * 32 * scaleX,
-      22 * 32 * scaleY
+      offsetX + 17 * 16 * scaleX,
+      offsetY + 16 * 16 * scaleY,
+      4 * 16 * scaleX,
+      22 * 16 * scaleY
     );
     this.zoneGraphics.fillRect(
-      offsetX + 37 * 32 * scaleX,
-      offsetY + 18 * 32 * scaleY,
-      3 * 32 * scaleX,
-      15 * 32 * scaleY
+      offsetX + 37 * 16 * scaleX,
+      offsetY + 18 * 16 * scaleY,
+      3 * 16 * scaleX,
+      15 * 16 * scaleY
     );
     this.zoneGraphics.fillRect(
-      offsetX + 17 * 32 * scaleX,
-      offsetY + 36 * 32 * scaleY,
-      41 * 32 * scaleX,
-      14 * 32 * scaleY
+      offsetX + 17 * 16 * scaleX,
+      offsetY + 36 * 16 * scaleY,
+      41 * 16 * scaleX,
+      14 * 16 * scaleY
     );
 
     for (const zoneId of ZONE_IDS) {

--- a/packages/client/src/world/TileInterpreter.ts
+++ b/packages/client/src/world/TileInterpreter.ts
@@ -39,7 +39,7 @@ export class TileInterpreter {
   private tileSize: number;
   private worldGrid: WorldGrid | null = null;
 
-  constructor(tileSize: number = 32) {
+  constructor(tileSize: number = 16) {
     this.tileSize = tileSize;
   }
 

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -44,14 +44,14 @@ export const MAX_MOVE_SPEED = 200;
 /**
  * Default tile size in pixels.
  */
-export const DEFAULT_TILE_SIZE = 32;
+export const DEFAULT_TILE_SIZE = 16;
 
 /**
  * Default spawn position (plaza center) for entities when no spawn point is configured.
  */
 export const DEFAULT_SPAWN_POSITION = {
-  x: 1024,
-  y: 1024,
+  x: 512,
+  y: 512,
 } as const;
 
 function parseEnvInt(envVar: string | undefined, defaultValue: number): number {

--- a/packages/server/src/world/WorldPackLoader.ts
+++ b/packages/server/src/world/WorldPackLoader.ts
@@ -318,8 +318,8 @@ export class WorldPackLoader {
         spawnPoints: zoneSpawns.map(sp => ({ x: sp.x, y: sp.y })),
         width: raw.width ?? 64,
         height: raw.height ?? 52,
-        tileWidth: raw.tilewidth ?? 32,
-        tileHeight: raw.tileheight ?? 32,
+        tileWidth: raw.tilewidth ?? 16,
+        tileHeight: raw.tileheight ?? 16,
         layers: raw.layers ?? [],
         objects: zoneObjects,
         npcs: (raw.npcs ?? []).filter(npc => this.getNpcZone(npc, zoneId)),
@@ -534,8 +534,8 @@ export class WorldPackLoader {
     }
 
     if (spawnPoints.length === 0) {
-      const tileWidth = raw.tilewidth ?? 32;
-      const tileHeight = raw.tileheight ?? 32;
+      const tileWidth = raw.tilewidth ?? 16;
+      const tileHeight = raw.tileheight ?? 16;
       const mapWidth = raw.width ?? 10;
       const mapHeight = raw.height ?? 10;
 
@@ -593,7 +593,7 @@ export class WorldPackLoader {
   }
 
   private getDefaultZoneBounds(zoneId: ZoneId): ZoneBounds {
-    return ZONE_BOUNDS[zoneId] ?? { x: 0, y: 0, width: 320, height: 320 };
+    return ZONE_BOUNDS[zoneId] ?? { x: 0, y: 0, width: 160, height: 160 };
   }
 
   private formatZoneName(zoneId: ZoneId): string {

--- a/packages/shared/src/world.ts
+++ b/packages/shared/src/world.ts
@@ -17,25 +17,25 @@ export type SpawnPoint = {
 export const MAP_CONFIG = {
   width: 64,
   height: 64,
-  tileSize: 32,
-  pixelWidth: 2048,
-  pixelHeight: 2048,
+  tileSize: 16,
+  pixelWidth: 1024,
+  pixelHeight: 1024,
 } as const;
 
 export const ZONE_BOUNDS: Record<ZoneId, ZoneBounds> = {
-  lobby: { x: 192, y: 64, width: 384, height: 384 },
-  office: { x: 1344, y: 64, width: 640, height: 448 },
-  'central-park': { x: 640, y: 512, width: 768, height: 640 },
-  arcade: { x: 1408, y: 512, width: 576, height: 512 },
-  meeting: { x: 64, y: 896, width: 512, height: 576 },
-  'lounge-cafe': { x: 576, y: 1216, width: 640, height: 448 },
-  plaza: { x: 1216, y: 1216, width: 512, height: 512 },
-  lake: { x: 64, y: 64, width: 128, height: 448 },
+  lobby: { x: 96, y: 32, width: 192, height: 192 },
+  office: { x: 672, y: 32, width: 320, height: 224 },
+  'central-park': { x: 320, y: 256, width: 384, height: 320 },
+  arcade: { x: 704, y: 256, width: 288, height: 256 },
+  meeting: { x: 32, y: 448, width: 256, height: 288 },
+  'lounge-cafe': { x: 288, y: 608, width: 320, height: 224 },
+  plaza: { x: 608, y: 608, width: 256, height: 256 },
+  lake: { x: 32, y: 32, width: 64, height: 224 },
 };
 
 export const DEFAULT_SPAWN_POINT: SpawnPoint = {
-  x: 1024,
-  y: 1024,
+  x: 512,
+  y: 512,
   tx: 32,
   ty: 32,
 };

--- a/tests/unit/world-pack.test.ts
+++ b/tests/unit/world-pack.test.ts
@@ -57,8 +57,8 @@ function createTestPack(
           facilities: [],
           width: 10,
           height: 10,
-          tilewidth: 32,
-          tileheight: 32,
+          tilewidth: 16,
+          tileheight: 16,
           layers: [
             {
               id: 1,
@@ -317,7 +317,7 @@ describe('MapLoader zone support', () => {
       const parsedMap = mapLoader.loadZoneMapFromData(zoneMapData);
 
       expect(parsedMap.mapId).toBe('plaza');
-      expect(parsedMap.tileSize).toBe(32);
+      expect(parsedMap.tileSize).toBe(16);
       expect(parsedMap.collisionGrid.length).toBe(10);
     });
   });

--- a/tests/unit/world.test.ts
+++ b/tests/unit/world.test.ts
@@ -7,7 +7,7 @@ import { EntitySchema } from '../../packages/server/src/schemas/EntitySchema.js'
 import { WanderBot } from '../../packages/server/src/bots/WanderBot.js';
 import type { ParsedMap, ZoneId } from '@openclawworld/shared';
 
-const TILE_SIZE = 32;
+const TILE_SIZE = 16;
 const MAP_WIDTH = 64;
 const MAP_HEIGHT = 64;
 
@@ -39,7 +39,7 @@ function createTestMap(blockedTiles: Array<{ tx: number; ty: number }> = []): Pa
 }
 
 describe('World System Integration Tests', () => {
-  describe('Scenario A: Player walks into central-park triggers zone.enter event', () => {
+  describe('Scenario A: Player walks into lobby triggers zone.enter event', () => {
     let zoneSystem: ZoneSystem;
     let eventLog: EventLog;
     let entity: EntitySchema;
@@ -50,22 +50,22 @@ describe('World System Integration Tests', () => {
       entity = new EntitySchema('player_1', 'human', 'TestPlayer', 'room_1');
     });
 
-    it('emits zone.enter when moving from outside into central-park', () => {
-      entity.setPosition(50, 50);
-      zoneSystem.updateEntityZone('player_1', 50, 50, eventLog, 'room_1', entity);
+    it('emits zone.enter when moving from outside into lobby', () => {
+      entity.setPosition(300, 300);
+      zoneSystem.updateEntityZone('player_1', 300, 300, eventLog, 'room_1', entity);
       expect(zoneSystem.getEntityZone('player_1')).toBeNull();
 
-      entity.setPosition(1024, 832);
-      const result = zoneSystem.updateEntityZone('player_1', 1024, 832, eventLog, 'room_1', entity);
+      entity.setPosition(160, 128);
+      const result = zoneSystem.updateEntityZone('player_1', 160, 128, eventLog, 'room_1', entity);
 
       expect(result.changed).toBe(true);
       expect(result.previousZone).toBeNull();
-      expect(result.currentZone).toBe('central-park');
-      expect(zoneSystem.getEntityZone('player_1')).toBe('central-park');
+      expect(result.currentZone).toBe('lobby');
+      expect(zoneSystem.getEntityZone('player_1')).toBe('lobby');
 
       const { events } = eventLog.getSince('', 10);
       const enterEvent = events.find(
-        e => e.type === 'zone.enter' && (e.payload as { zoneId: string }).zoneId === 'central-park'
+        e => e.type === 'zone.enter' && (e.payload as { zoneId: string }).zoneId === 'lobby'
       );
       expect(enterEvent).toBeDefined();
       expect((enterEvent?.payload as { entityId: string }).entityId).toBe('player_1');
@@ -73,14 +73,14 @@ describe('World System Integration Tests', () => {
     });
 
     it('updates entity currentZone property on enter', () => {
-      entity.setPosition(1024, 832);
-      zoneSystem.updateEntityZone('player_1', 1024, 832, eventLog, 'room_1', entity);
+      entity.setPosition(160, 128);
+      zoneSystem.updateEntityZone('player_1', 160, 128, eventLog, 'room_1', entity);
 
-      expect(entity.currentZone).toBe('central-park');
+      expect(entity.currentZone).toBe('lobby');
     });
   });
 
-  describe('Scenario B: Player exits central-park triggers zone.exit event', () => {
+  describe('Scenario B: Player exits lobby triggers zone.exit event', () => {
     let zoneSystem: ZoneSystem;
     let eventLog: EventLog;
     let entity: EntitySchema;
@@ -90,22 +90,22 @@ describe('World System Integration Tests', () => {
       eventLog = new EventLog(60000, 1000);
       entity = new EntitySchema('player_1', 'human', 'TestPlayer', 'room_1');
 
-      entity.setPosition(1024, 832);
-      zoneSystem.updateEntityZone('player_1', 1024, 832, eventLog, 'room_1', entity);
+      entity.setPosition(160, 128);
+      zoneSystem.updateEntityZone('player_1', 160, 128, eventLog, 'room_1', entity);
       eventLog.getSince('', 100);
     });
 
-    it('emits zone.exit when leaving central-park to outside', () => {
-      entity.setPosition(50, 50);
-      const result = zoneSystem.updateEntityZone('player_1', 50, 50, eventLog, 'room_1', entity);
+    it('emits zone.exit when leaving lobby to outside', () => {
+      entity.setPosition(25, 250);
+      const result = zoneSystem.updateEntityZone('player_1', 25, 250, eventLog, 'room_1', entity);
 
       expect(result.changed).toBe(true);
-      expect(result.previousZone).toBe('central-park');
+      expect(result.previousZone).toBe('lobby');
       expect(result.currentZone).toBeNull();
 
       const { events } = eventLog.getSince('', 10);
       const exitEvent = events.find(
-        e => e.type === 'zone.exit' && (e.payload as { zoneId: string }).zoneId === 'central-park'
+        e => e.type === 'zone.exit' && (e.payload as { zoneId: string }).zoneId === 'lobby'
       );
       expect(exitEvent).toBeDefined();
       expect((exitEvent?.payload as { entityId: string }).entityId).toBe('player_1');
@@ -113,28 +113,26 @@ describe('World System Integration Tests', () => {
     });
 
     it('emits both zone.exit and zone.enter when transitioning between zones', () => {
-      entity.setPosition(1500, 700);
-      const result = zoneSystem.updateEntityZone('player_1', 1500, 700, eventLog, 'room_1', entity);
+      entity.setPosition(832, 144);
+      const result = zoneSystem.updateEntityZone('player_1', 832, 144, eventLog, 'room_1', entity);
 
       expect(result.changed).toBe(true);
-      expect(result.previousZone).toBe('central-park');
-      expect(result.currentZone).toBe('arcade');
+      expect(result.previousZone).toBe('lobby');
+      expect(result.currentZone).toBe('office');
 
       const { events } = eventLog.getSince('', 10);
 
       const exitEvent = events.find(
-        e => e.type === 'zone.exit' && (e.payload as { zoneId: string }).zoneId === 'central-park'
+        e => e.type === 'zone.exit' && (e.payload as { zoneId: string }).zoneId === 'lobby'
       );
       const enterEvent = events.find(
-        e => e.type === 'zone.enter' && (e.payload as { zoneId: string }).zoneId === 'arcade'
+        e => e.type === 'zone.enter' && (e.payload as { zoneId: string }).zoneId === 'office'
       );
 
       expect(exitEvent).toBeDefined();
       expect(enterEvent).toBeDefined();
-      expect((exitEvent?.payload as { nextZoneId: string }).nextZoneId).toBe('arcade');
-      expect((enterEvent?.payload as { previousZoneId: string }).previousZoneId).toBe(
-        'central-park'
-      );
+      expect((exitEvent?.payload as { nextZoneId: string }).nextZoneId).toBe('office');
+      expect((enterEvent?.payload as { previousZoneId: string }).previousZoneId).toBe('lobby');
     });
   });
 
@@ -203,8 +201,8 @@ describe('World System Integration Tests', () => {
       eventLog = new EventLog(60000, 1000);
       entity = new EntitySchema('bot_1', 'agent', 'WanderBot', 'room_1');
 
-      entity.setPosition(1024, 832);
-      entity.setTile(32, 26);
+      entity.setPosition(160, 128);
+      entity.setTile(10, 8);
 
       wanderBot = new WanderBot(
         {
@@ -223,27 +221,27 @@ describe('World System Integration Tests', () => {
       wanderBot.start();
     });
 
-    it('bot starts in central-park zone', () => {
-      expect(wanderBot.getCurrentZone()).toBe('central-park');
-      expect(wanderBot.getZonesVisited()).toContain('central-park');
+    it('bot starts in lobby zone', () => {
+      expect(wanderBot.getCurrentZone()).toBe('lobby');
+      expect(wanderBot.getZonesVisited()).toContain('lobby');
     });
 
-    it('bot can move to arcade zone', () => {
-      entity.setPosition(1500, 700);
-      entity.setTile(47, 22);
+    it('bot can move to office zone', () => {
+      entity.setPosition(832, 144);
+      entity.setTile(52, 9);
 
       wanderBot.update(Date.now());
 
-      expect(wanderBot.getCurrentZone()).toBe('arcade');
-      expect(wanderBot.getZonesVisited()).toContain('central-park');
-      expect(wanderBot.getZonesVisited()).toContain('arcade');
+      expect(wanderBot.getCurrentZone()).toBe('office');
+      expect(wanderBot.getZonesVisited()).toContain('lobby');
+      expect(wanderBot.getZonesVisited()).toContain('office');
     });
 
     it('bot visits at least 3 zones when manually moved', () => {
       const zonePositions: Array<{ zone: ZoneId; x: number; y: number }> = [
-        { zone: 'central-park', x: 1024, y: 832 },
-        { zone: 'arcade', x: 1500, y: 700 },
-        { zone: 'lounge-cafe', x: 800, y: 1300 },
+        { zone: 'lobby', x: 160, y: 128 },
+        { zone: 'office', x: 832, y: 144 },
+        { zone: 'meeting', x: 160, y: 592 },
       ];
 
       for (const { x, y } of zonePositions) {
@@ -253,9 +251,9 @@ describe('World System Integration Tests', () => {
 
       const visited = wanderBot.getZonesVisited();
       expect(visited.length).toBeGreaterThanOrEqual(3);
-      expect(visited).toContain('central-park');
-      expect(visited).toContain('arcade');
-      expect(visited).toContain('lounge-cafe');
+      expect(visited).toContain('lobby');
+      expect(visited).toContain('office');
+      expect(visited).toContain('meeting');
     });
 
     it('bot respects collision when trying to move', () => {
@@ -292,8 +290,8 @@ describe('World System Integration Tests', () => {
     it('bot tracks move count correctly', () => {
       const initialCount = wanderBot.getMoveCount();
 
-      entity.setPosition(1200, 900);
-      wanderBot.moveTo(38, 28);
+      entity.setPosition(600, 200);
+      wanderBot.moveTo(38, 13);
 
       expect(wanderBot.getMoveCount()).toBe(initialCount + 1);
     });
@@ -301,20 +299,20 @@ describe('World System Integration Tests', () => {
     it('zone events are logged when bot moves between zones', () => {
       eventLog.getSince('', 100);
 
-      entity.setPosition(1500, 700);
+      entity.setPosition(832, 144);
       wanderBot.update(Date.now());
 
       const { events } = eventLog.getSince('', 10);
 
-      const exitCentralPark = events.find(
-        e => e.type === 'zone.exit' && (e.payload as { zoneId: string }).zoneId === 'central-park'
+      const exitLobby = events.find(
+        e => e.type === 'zone.exit' && (e.payload as { zoneId: string }).zoneId === 'lobby'
       );
-      const enterArcade = events.find(
-        e => e.type === 'zone.enter' && (e.payload as { zoneId: string }).zoneId === 'arcade'
+      const enterOffice = events.find(
+        e => e.type === 'zone.enter' && (e.payload as { zoneId: string }).zoneId === 'office'
       );
 
-      expect(exitCentralPark).toBeDefined();
-      expect(enterArcade).toBeDefined();
+      expect(exitLobby).toBeDefined();
+      expect(enterOffice).toBeDefined();
     });
   });
 

--- a/tests/unit/zone-system-64x64.test.ts
+++ b/tests/unit/zone-system-64x64.test.ts
@@ -3,7 +3,7 @@ import { ZoneSystem, DEFAULT_ZONE_BOUNDS } from '../../packages/server/src/zone/
 import { EventLog } from '../../packages/server/src/events/EventLog.js';
 import { EntitySchema } from '../../packages/server/src/schemas/EntitySchema.js';
 
-describe('ZoneSystem - 64x64 Grid-Town Layout (2048x2048 pixels)', () => {
+describe('ZoneSystem - 64x64 Grid-Town Layout (1024x1024 pixels)', () => {
   let zoneSystem: ZoneSystem;
   let eventLog: EventLog;
 
@@ -25,133 +25,165 @@ describe('ZoneSystem - 64x64 Grid-Town Layout (2048x2048 pixels)', () => {
       expect(DEFAULT_ZONE_BOUNDS.has('lake')).toBe(true);
     });
 
-    it('lobby has correct bounds (192,64,384,384)', () => {
+    it('lobby has correct bounds (96,32,192,192)', () => {
       const bounds = DEFAULT_ZONE_BOUNDS.get('lobby');
-      expect(bounds).toEqual({ x: 192, y: 64, width: 384, height: 384 });
+      expect(bounds).toEqual({ x: 96, y: 32, width: 192, height: 192 });
     });
 
-    it('office has correct bounds (1344,64,640,448)', () => {
+    it('office has correct bounds (672,32,320,224)', () => {
       const bounds = DEFAULT_ZONE_BOUNDS.get('office');
-      expect(bounds).toEqual({ x: 1344, y: 64, width: 640, height: 448 });
+      expect(bounds).toEqual({ x: 672, y: 32, width: 320, height: 224 });
     });
 
-    it('central-park has correct bounds (640,512,768,640)', () => {
+    it('central-park has correct bounds (320,256,384,320)', () => {
       const bounds = DEFAULT_ZONE_BOUNDS.get('central-park');
-      expect(bounds).toEqual({ x: 640, y: 512, width: 768, height: 640 });
+      expect(bounds).toEqual({ x: 320, y: 256, width: 384, height: 320 });
     });
 
-    it('arcade has correct bounds (1408,512,576,512)', () => {
+    it('arcade has correct bounds (704,256,288,256)', () => {
       const bounds = DEFAULT_ZONE_BOUNDS.get('arcade');
-      expect(bounds).toEqual({ x: 1408, y: 512, width: 576, height: 512 });
+      expect(bounds).toEqual({ x: 704, y: 256, width: 288, height: 256 });
     });
 
-    it('meeting has correct bounds (64,896,512,576)', () => {
+    it('meeting has correct bounds (32,448,256,288)', () => {
       const bounds = DEFAULT_ZONE_BOUNDS.get('meeting');
-      expect(bounds).toEqual({ x: 64, y: 896, width: 512, height: 576 });
+      expect(bounds).toEqual({ x: 32, y: 448, width: 256, height: 288 });
     });
 
-    it('lounge-cafe has correct bounds (576,1216,640,448)', () => {
+    it('lounge-cafe has correct bounds (288,608,320,224)', () => {
       const bounds = DEFAULT_ZONE_BOUNDS.get('lounge-cafe');
-      expect(bounds).toEqual({ x: 576, y: 1216, width: 640, height: 448 });
+      expect(bounds).toEqual({ x: 288, y: 608, width: 320, height: 224 });
     });
 
-    it('plaza has correct bounds (1216,1216,512,512)', () => {
+    it('plaza has correct bounds (608,608,256,256)', () => {
       const bounds = DEFAULT_ZONE_BOUNDS.get('plaza');
-      expect(bounds).toEqual({ x: 1216, y: 1216, width: 512, height: 512 });
+      expect(bounds).toEqual({ x: 608, y: 608, width: 256, height: 256 });
     });
 
-    it('lake has correct bounds (64,64,128,448)', () => {
+    it('lake has correct bounds (32,32,64,224)', () => {
       const bounds = DEFAULT_ZONE_BOUNDS.get('lake');
-      expect(bounds).toEqual({ x: 64, y: 64, width: 128, height: 448 });
+      expect(bounds).toEqual({ x: 32, y: 32, width: 64, height: 224 });
     });
   });
 
-  describe('detectZone with 8-zone Grid-Town positions', () => {
-    describe('lobby zone (192,64) to (576,448)', () => {
-      it('detects lobby at center (384,256)', () => {
-        expect(zoneSystem.detectZone(384, 256)).toBe('lobby');
+  describe('detectZone with new 8-zone layout positions', () => {
+    describe('plaza zone (608,608) to (863,863)', () => {
+      it('detects plaza at center (736,736)', () => {
+        expect(zoneSystem.detectZone(736, 736)).toBe('plaza');
       });
 
-      it('detects lobby at origin (192,64)', () => {
-        expect(zoneSystem.detectZone(192, 64)).toBe('lobby');
+      it('detects plaza at origin (608,608)', () => {
+        expect(zoneSystem.detectZone(608, 608)).toBe('plaza');
       });
 
-      it('detects lobby just inside right edge (575,256)', () => {
-        expect(zoneSystem.detectZone(575, 256)).toBe('lobby');
-      });
-    });
-
-    describe('office zone (1344,64) to (1984,512)', () => {
-      it('detects office at center (1664,288)', () => {
-        expect(zoneSystem.detectZone(1664, 288)).toBe('office');
+      it('detects plaza just inside right edge (863,736)', () => {
+        expect(zoneSystem.detectZone(863, 736)).toBe('plaza');
       });
 
-      it('detects office at origin (1344,64)', () => {
-        expect(zoneSystem.detectZone(1344, 64)).toBe('office');
+      it('returns null just outside plaza right edge (864,736)', () => {
+        expect(zoneSystem.detectZone(864, 736)).toBeNull();
+      });
+
+      it('detects plaza just inside bottom edge (736,863)', () => {
+        expect(zoneSystem.detectZone(736, 863)).toBe('plaza');
       });
     });
 
-    describe('central-park zone (640,512) to (1408,1152)', () => {
-      it('detects central-park at center (1024,832)', () => {
-        expect(zoneSystem.detectZone(1024, 832)).toBe('central-park');
+    describe('lobby zone (96,32) to (287,223)', () => {
+      it('detects lobby at center (192,128)', () => {
+        expect(zoneSystem.detectZone(192, 128)).toBe('lobby');
       });
 
-      it('detects central-park at origin (640,512)', () => {
-        expect(zoneSystem.detectZone(640, 512)).toBe('central-park');
-      });
-    });
-
-    describe('arcade zone (1408,512) to (1984,1024)', () => {
-      it('detects arcade at center (1696,768)', () => {
-        expect(zoneSystem.detectZone(1696, 768)).toBe('arcade');
+      it('detects lobby at origin (96,32)', () => {
+        expect(zoneSystem.detectZone(96, 32)).toBe('lobby');
       });
 
-      it('detects arcade at origin (1408,512)', () => {
-        expect(zoneSystem.detectZone(1408, 512)).toBe('arcade');
+      it('detects lobby just inside bottom-right (287,223)', () => {
+        expect(zoneSystem.detectZone(287, 223)).toBe('lobby');
       });
     });
 
-    describe('meeting zone (64,896) to (576,1472)', () => {
-      it('detects meeting at center (320,1184)', () => {
-        expect(zoneSystem.detectZone(320, 1184)).toBe('meeting');
+    describe('office zone (672,32) to (991,255)', () => {
+      it('detects office at center (832,144)', () => {
+        expect(zoneSystem.detectZone(832, 144)).toBe('office');
       });
 
-      it('detects meeting at origin (64,896)', () => {
-        expect(zoneSystem.detectZone(64, 896)).toBe('meeting');
-      });
-    });
-
-    describe('lounge-cafe zone (576,1216) to (1216,1664)', () => {
-      it('detects lounge-cafe at center (896,1440)', () => {
-        expect(zoneSystem.detectZone(896, 1440)).toBe('lounge-cafe');
+      it('detects office at origin (672,32)', () => {
+        expect(zoneSystem.detectZone(672, 32)).toBe('office');
       });
 
-      it('detects lounge-cafe at origin (576,1216)', () => {
-        expect(zoneSystem.detectZone(576, 1216)).toBe('lounge-cafe');
+      it('detects office just inside bottom-right (991,255)', () => {
+        expect(zoneSystem.detectZone(991, 255)).toBe('office');
       });
     });
 
-    describe('plaza zone (1216,1216) to (1728,1728)', () => {
-      it('detects plaza at center (1472,1472)', () => {
-        expect(zoneSystem.detectZone(1472, 1472)).toBe('plaza');
+    describe('central-park zone (320,256) to (703,575)', () => {
+      it('detects central-park at center (512,416)', () => {
+        expect(zoneSystem.detectZone(512, 416)).toBe('central-park');
       });
 
-      it('detects plaza at origin (1216,1216)', () => {
-        expect(zoneSystem.detectZone(1216, 1216)).toBe('plaza');
+      it('detects central-park at origin (320,256)', () => {
+        expect(zoneSystem.detectZone(320, 256)).toBe('central-park');
       });
 
-      it('detects plaza just inside right edge (1727,1472)', () => {
-        expect(zoneSystem.detectZone(1727, 1472)).toBe('plaza');
+      it('detects central-park just inside bottom-right (703,575)', () => {
+        expect(zoneSystem.detectZone(703, 575)).toBe('central-park');
       });
     });
 
-    describe('lake zone (64,64) to (192,512)', () => {
-      it('detects lake at center (128,288)', () => {
-        expect(zoneSystem.detectZone(128, 288)).toBe('lake');
+    describe('arcade zone (704,256) to (991,511)', () => {
+      it('detects arcade at center (848,384)', () => {
+        expect(zoneSystem.detectZone(848, 384)).toBe('arcade');
       });
 
-      it('detects lake at origin (64,64)', () => {
-        expect(zoneSystem.detectZone(64, 64)).toBe('lake');
+      it('detects arcade at origin (704,256)', () => {
+        expect(zoneSystem.detectZone(704, 256)).toBe('arcade');
+      });
+
+      it('detects arcade just inside bottom-right (991,511)', () => {
+        expect(zoneSystem.detectZone(991, 511)).toBe('arcade');
+      });
+    });
+
+    describe('meeting zone (32,448) to (287,735)', () => {
+      it('detects meeting at center (160,592)', () => {
+        expect(zoneSystem.detectZone(160, 592)).toBe('meeting');
+      });
+
+      it('detects meeting at origin (32,448)', () => {
+        expect(zoneSystem.detectZone(32, 448)).toBe('meeting');
+      });
+
+      it('detects meeting just inside bottom-right (287,735)', () => {
+        expect(zoneSystem.detectZone(287, 735)).toBe('meeting');
+      });
+    });
+
+    describe('lounge-cafe zone (288,608) to (607,831)', () => {
+      it('detects lounge-cafe at center (448,720)', () => {
+        expect(zoneSystem.detectZone(448, 720)).toBe('lounge-cafe');
+      });
+
+      it('detects lounge-cafe at origin (288,608)', () => {
+        expect(zoneSystem.detectZone(288, 608)).toBe('lounge-cafe');
+      });
+
+      it('detects lounge-cafe just inside bottom-right (607,831)', () => {
+        expect(zoneSystem.detectZone(607, 831)).toBe('lounge-cafe');
+      });
+    });
+
+    describe('lake zone (32,32) to (95,255)', () => {
+      it('detects lake at center (64,144)', () => {
+        expect(zoneSystem.detectZone(64, 144)).toBe('lake');
+      });
+
+      it('detects lake at origin (32,32)', () => {
+        expect(zoneSystem.detectZone(32, 32)).toBe('lake');
+      });
+
+      it('detects lake just inside bottom-right (95,255)', () => {
+        expect(zoneSystem.detectZone(95, 255)).toBe('lake');
       });
     });
 
@@ -160,78 +192,89 @@ describe('ZoneSystem - 64x64 Grid-Town Layout (2048x2048 pixels)', () => {
         expect(zoneSystem.detectZone(0, 0)).toBeNull();
       });
 
-      it('returns null for position beyond map (2100,2100)', () => {
-        expect(zoneSystem.detectZone(2100, 2100)).toBeNull();
+      it('returns null for position beyond map (1050,1050)', () => {
+        expect(zoneSystem.detectZone(1050, 1050)).toBeNull();
       });
 
-      it('returns null for gap between zones', () => {
-        expect(zoneSystem.detectZone(600, 200)).toBeNull();
+      it('returns null for gap between zones (500,50)', () => {
+        expect(zoneSystem.detectZone(500, 50)).toBeNull();
       });
     });
   });
 
   describe('spawn points are inside correct zones', () => {
-    it('spawn position (384,256) is inside lobby', () => {
-      expect(zoneSystem.detectZone(384, 256)).toBe('lobby');
+    it('spawn_plaza position (736,736) is inside plaza', () => {
+      expect(zoneSystem.detectZone(736, 736)).toBe('plaza');
     });
 
-    it('spawn position (1664,288) is inside office', () => {
-      expect(zoneSystem.detectZone(1664, 288)).toBe('office');
+    it('spawn_lobby position (192,128) is inside lobby', () => {
+      expect(zoneSystem.detectZone(192, 128)).toBe('lobby');
     });
 
-    it('spawn position (1024,832) is inside central-park', () => {
-      expect(zoneSystem.detectZone(1024, 832)).toBe('central-park');
+    it('spawn_office position (832,144) is inside office', () => {
+      expect(zoneSystem.detectZone(832, 144)).toBe('office');
     });
 
-    it('spawn position (1696,768) is inside arcade', () => {
-      expect(zoneSystem.detectZone(1696, 768)).toBe('arcade');
+    it('spawn_central_park position (512,416) is inside central-park', () => {
+      expect(zoneSystem.detectZone(512, 416)).toBe('central-park');
     });
 
-    it('spawn position (320,1184) is inside meeting', () => {
-      expect(zoneSystem.detectZone(320, 1184)).toBe('meeting');
+    it('spawn_arcade position (848,384) is inside arcade', () => {
+      expect(zoneSystem.detectZone(848, 384)).toBe('arcade');
     });
 
-    it('spawn position (896,1440) is inside lounge-cafe', () => {
-      expect(zoneSystem.detectZone(896, 1440)).toBe('lounge-cafe');
+    it('spawn_meeting position (160,592) is inside meeting', () => {
+      expect(zoneSystem.detectZone(160, 592)).toBe('meeting');
     });
 
-    it('spawn position (1472,1472) is inside plaza', () => {
-      expect(zoneSystem.detectZone(1472, 1472)).toBe('plaza');
+    it('spawn_lounge_cafe position (448,720) is inside lounge-cafe', () => {
+      expect(zoneSystem.detectZone(448, 720)).toBe('lounge-cafe');
     });
 
-    it('spawn position (128,288) is inside lake', () => {
-      expect(zoneSystem.detectZone(128, 288)).toBe('lake');
+    it('spawn_lake position (64,144) is inside lake', () => {
+      expect(zoneSystem.detectZone(64, 144)).toBe('lake');
     });
   });
 
-  describe('zone transitions in 8-zone Grid-Town layout', () => {
-    it('transitions from lobby to central-park via vertical movement', () => {
-      zoneSystem.updateEntityZone('entity_1', 384, 256, eventLog, 'room_1');
-      expect(zoneSystem.getEntityZone('entity_1')).toBe('lobby');
+  describe('zone transitions in new 8-zone layout', () => {
+    it('transitions from central-park to office via movement', () => {
+      zoneSystem.updateEntityZone('entity_1', 550, 416, eventLog, 'room_1');
+      expect(zoneSystem.getEntityZone('entity_1')).toBe('central-park');
 
-      const result = zoneSystem.updateEntityZone('entity_1', 700, 600, eventLog, 'room_1');
+      const result = zoneSystem.updateEntityZone('entity_1', 700, 144, eventLog, 'room_1');
 
-      expect(result.previousZone).toBe('lobby');
-      expect(result.currentZone).toBe('central-park');
+      expect(result.previousZone).toBe('central-park');
+      expect(result.currentZone).toBe('office');
       expect(result.changed).toBe(true);
     });
 
-    it('transitions from central-park to arcade via horizontal movement', () => {
-      zoneSystem.updateEntityZone('entity_1', 1000, 700, eventLog, 'room_1');
+    it('transitions from central-park to meeting via movement', () => {
+      zoneSystem.updateEntityZone('entity_1', 350, 450, eventLog, 'room_1');
       expect(zoneSystem.getEntityZone('entity_1')).toBe('central-park');
 
-      const result = zoneSystem.updateEntityZone('entity_1', 1500, 700, eventLog, 'room_1');
+      const result = zoneSystem.updateEntityZone('entity_1', 150, 550, eventLog, 'room_1');
+
+      expect(result.previousZone).toBe('central-park');
+      expect(result.currentZone).toBe('meeting');
+      expect(result.changed).toBe(true);
+    });
+
+    it('transitions from central-park to arcade via movement', () => {
+      zoneSystem.updateEntityZone('entity_1', 650, 416, eventLog, 'room_1');
+      expect(zoneSystem.getEntityZone('entity_1')).toBe('central-park');
+
+      const result = zoneSystem.updateEntityZone('entity_1', 750, 350, eventLog, 'room_1');
 
       expect(result.previousZone).toBe('central-park');
       expect(result.currentZone).toBe('arcade');
       expect(result.changed).toBe(true);
     });
 
-    it('transitions from central-park to lounge-cafe via vertical movement', () => {
-      zoneSystem.updateEntityZone('entity_1', 800, 800, eventLog, 'room_1');
+    it('transitions from central-park to lounge-cafe via movement', () => {
+      zoneSystem.updateEntityZone('entity_1', 450, 575, eventLog, 'room_1');
       expect(zoneSystem.getEntityZone('entity_1')).toBe('central-park');
 
-      const result = zoneSystem.updateEntityZone('entity_1', 800, 1300, eventLog, 'room_1');
+      const result = zoneSystem.updateEntityZone('entity_1', 448, 650, eventLog, 'room_1');
 
       expect(result.previousZone).toBe('central-park');
       expect(result.currentZone).toBe('lounge-cafe');
@@ -239,10 +282,10 @@ describe('ZoneSystem - 64x64 Grid-Town Layout (2048x2048 pixels)', () => {
     });
 
     it('transitions from lounge-cafe to plaza via horizontal movement', () => {
-      zoneSystem.updateEntityZone('entity_1', 800, 1400, eventLog, 'room_1');
+      zoneSystem.updateEntityZone('entity_1', 448, 720, eventLog, 'room_1');
       expect(zoneSystem.getEntityZone('entity_1')).toBe('lounge-cafe');
 
-      const result = zoneSystem.updateEntityZone('entity_1', 1300, 1400, eventLog, 'room_1');
+      const result = zoneSystem.updateEntityZone('entity_1', 736, 720, eventLog, 'room_1');
 
       expect(result.previousZone).toBe('lounge-cafe');
       expect(result.currentZone).toBe('plaza');
@@ -252,37 +295,37 @@ describe('ZoneSystem - 64x64 Grid-Town Layout (2048x2048 pixels)', () => {
     it('emits zone.exit and zone.enter events on transition', () => {
       const entity = new EntitySchema('entity_1', 'human', 'Test', 'room_1');
 
-      zoneSystem.updateEntityZone('entity_1', 384, 256, eventLog, 'room_1', entity);
-      zoneSystem.updateEntityZone('entity_1', 700, 600, eventLog, 'room_1', entity);
+      zoneSystem.updateEntityZone('entity_1', 550, 416, eventLog, 'room_1', entity);
+      zoneSystem.updateEntityZone('entity_1', 700, 144, eventLog, 'room_1', entity);
 
       const { events } = eventLog.getSince('', 10);
 
-      const exitLobby = events.find(
-        e => e.type === 'zone.exit' && (e.payload as { zoneId: string }).zoneId === 'lobby'
+      const exitCentralPark = events.find(
+        e => e.type === 'zone.exit' && (e.payload as { zoneId: string }).zoneId === 'central-park'
       );
-      const enterCentralPark = events.find(
-        e => e.type === 'zone.enter' && (e.payload as { zoneId: string }).zoneId === 'central-park'
+      const enterOffice = events.find(
+        e => e.type === 'zone.enter' && (e.payload as { zoneId: string }).zoneId === 'office'
       );
 
-      expect(exitLobby).toBeDefined();
-      expect(enterCentralPark).toBeDefined();
-      expect((exitLobby?.payload as { nextZoneId: string }).nextZoneId).toBe('central-park');
-      expect((enterCentralPark?.payload as { previousZoneId: string }).previousZoneId).toBe(
-        'lobby'
+      expect(exitCentralPark).toBeDefined();
+      expect(enterOffice).toBeDefined();
+      expect((exitCentralPark?.payload as { nextZoneId: string }).nextZoneId).toBe('office');
+      expect((enterOffice?.payload as { previousZoneId: string }).previousZoneId).toBe(
+        'central-park'
       );
     });
   });
 
   describe('zone populations in 8-zone Grid-Town layout', () => {
     it('tracks population across all 8 zones', () => {
-      zoneSystem.updateEntityZone('e1', 384, 256); // lobby
-      zoneSystem.updateEntityZone('e2', 1664, 288); // office
-      zoneSystem.updateEntityZone('e3', 1024, 832); // central-park
-      zoneSystem.updateEntityZone('e4', 1696, 768); // arcade
-      zoneSystem.updateEntityZone('e5', 320, 1184); // meeting
-      zoneSystem.updateEntityZone('e6', 896, 1440); // lounge-cafe
-      zoneSystem.updateEntityZone('e7', 1472, 1472); // plaza
-      zoneSystem.updateEntityZone('e8', 128, 288); // lake
+      zoneSystem.updateEntityZone('e1', 736, 736);
+      zoneSystem.updateEntityZone('e2', 192, 128);
+      zoneSystem.updateEntityZone('e3', 832, 144);
+      zoneSystem.updateEntityZone('e4', 512, 416);
+      zoneSystem.updateEntityZone('e5', 848, 384);
+      zoneSystem.updateEntityZone('e6', 160, 592);
+      zoneSystem.updateEntityZone('e7', 448, 720);
+      zoneSystem.updateEntityZone('e8', 64, 144);
 
       expect(zoneSystem.getZonePopulation('lobby')).toBe(1);
       expect(zoneSystem.getZonePopulation('office')).toBe(1);
@@ -295,70 +338,70 @@ describe('ZoneSystem - 64x64 Grid-Town Layout (2048x2048 pixels)', () => {
     });
 
     it('getEntitiesInZone returns correct entities', () => {
-      zoneSystem.updateEntityZone('agent_1', 1024, 832); // central-park
-      zoneSystem.updateEntityZone('agent_2', 1100, 900); // central-park
-      zoneSystem.updateEntityZone('agent_3', 1696, 768); // arcade
+      zoneSystem.updateEntityZone('agent_1', 700, 700);
+      zoneSystem.updateEntityZone('agent_2', 750, 750);
+      zoneSystem.updateEntityZone('agent_3', 832, 144);
 
-      const centralParkEntities = zoneSystem.getEntitiesInZone('central-park');
-      const arcadeEntities = zoneSystem.getEntitiesInZone('arcade');
+      const plazaEntities = zoneSystem.getEntitiesInZone('plaza');
+      const officeEntities = zoneSystem.getEntitiesInZone('office');
 
-      expect(centralParkEntities).toHaveLength(2);
-      expect(centralParkEntities).toContain('agent_1');
-      expect(centralParkEntities).toContain('agent_2');
-      expect(arcadeEntities).toHaveLength(1);
-      expect(arcadeEntities).toContain('agent_3');
+      expect(plazaEntities).toHaveLength(2);
+      expect(plazaEntities).toContain('agent_1');
+      expect(plazaEntities).toContain('agent_2');
+      expect(officeEntities).toHaveLength(1);
+      expect(officeEntities).toContain('agent_3');
     });
   });
 
   describe('getZoneBounds returns 8-zone Grid-Town spec values', () => {
     it('returns correct bounds for all zones', () => {
       expect(zoneSystem.getZoneBounds('lobby')).toEqual({
-        x: 192,
-        y: 64,
-        width: 384,
-        height: 384,
+        x: 96,
+        y: 32,
+        width: 192,
+        height: 192,
       });
       expect(zoneSystem.getZoneBounds('office')).toEqual({
-        x: 1344,
-        y: 64,
-        width: 640,
-        height: 448,
+        x: 672,
+        y: 32,
+        width: 320,
+        height: 224,
       });
       expect(zoneSystem.getZoneBounds('central-park')).toEqual({
-        x: 640,
-        y: 512,
-        width: 768,
-        height: 640,
+        x: 320,
+        y: 256,
+        width: 384,
+        height: 320,
       });
       expect(zoneSystem.getZoneBounds('arcade')).toEqual({
-        x: 1408,
-        y: 512,
-        width: 576,
-        height: 512,
+        x: 704,
+        y: 256,
+        width: 288,
+        height: 256,
       });
       expect(zoneSystem.getZoneBounds('meeting')).toEqual({
-        x: 64,
-        y: 896,
-        width: 512,
-        height: 576,
+        x: 32,
+        y: 448,
+        width: 256,
+        height: 288,
       });
       expect(zoneSystem.getZoneBounds('lounge-cafe')).toEqual({
-        x: 576,
-        y: 1216,
-        width: 640,
-        height: 448,
+        x: 288,
+        y: 608,
+        width: 320,
+        height: 224,
       });
       expect(zoneSystem.getZoneBounds('plaza')).toEqual({
-        x: 1216,
-        y: 1216,
-        width: 512,
-        height: 512,
+        x: 608,
+        y: 608,
+        width: 256,
+        height: 256,
       });
       expect(zoneSystem.getZoneBounds('lake')).toEqual({
-        x: 64,
-        y: 64,
-        width: 128,
-        height: 448,
+        x: 32,
+        y: 32,
+        width: 64,
+        height: 224,
       });
     });
   });

--- a/tests/unit/zone-system-plaza.test.ts
+++ b/tests/unit/zone-system-plaza.test.ts
@@ -13,24 +13,24 @@ describe('ZoneSystem - Plaza Zone (8-zone Grid-Town layout)', () => {
   });
 
   describe('detectZone', () => {
-    it('returns plaza for position inside plaza bounds (1472, 1472)', () => {
-      expect(zoneSystem.detectZone(1472, 1472)).toBe('plaza');
+    it('returns plaza for position inside plaza bounds (736, 736)', () => {
+      expect(zoneSystem.detectZone(736, 736)).toBe('plaza');
     });
 
-    it('returns plaza for position at plaza origin (1216, 1216)', () => {
-      expect(zoneSystem.detectZone(1216, 1216)).toBe('plaza');
+    it('returns plaza for position at plaza origin (608, 608)', () => {
+      expect(zoneSystem.detectZone(608, 608)).toBe('plaza');
     });
 
-    it('returns plaza for position at plaza bottom-right boundary (1727, 1727)', () => {
-      expect(zoneSystem.detectZone(1727, 1727)).toBe('plaza');
+    it('returns plaza for position at plaza bottom-right boundary (863, 863)', () => {
+      expect(zoneSystem.detectZone(863, 863)).toBe('plaza');
     });
 
     it('returns null for position outside all zones', () => {
-      expect(zoneSystem.detectZone(5000, 500)).toBeNull();
+      expect(zoneSystem.detectZone(2500, 250)).toBeNull();
     });
 
     it('returns null for position just outside plaza to the right', () => {
-      expect(zoneSystem.detectZone(1728, 1472)).toBeNull();
+      expect(zoneSystem.detectZone(864, 736)).toBeNull();
     });
   });
 
@@ -38,14 +38,7 @@ describe('ZoneSystem - Plaza Zone (8-zone Grid-Town layout)', () => {
     it('fires zone.enter event when entity enters plaza', () => {
       const entity = new EntitySchema('entity_1', 'human', 'Test', 'room_1');
 
-      const result = zoneSystem.updateEntityZone(
-        'entity_1',
-        1472,
-        1472,
-        eventLog,
-        'room_1',
-        entity
-      );
+      const result = zoneSystem.updateEntityZone('entity_1', 736, 736, eventLog, 'room_1', entity);
 
       expect(result.currentZone).toBe('plaza');
       expect(result.changed).toBe(true);
@@ -62,13 +55,13 @@ describe('ZoneSystem - Plaza Zone (8-zone Grid-Town layout)', () => {
     it('updates entity currentZone to plaza when entity enters', () => {
       const entity = new EntitySchema('entity_1', 'human', 'Test', 'room_1');
 
-      zoneSystem.updateEntityZone('entity_1', 1472, 1472, eventLog, 'room_1', entity);
+      zoneSystem.updateEntityZone('entity_1', 736, 736, eventLog, 'room_1', entity);
 
       expect(entity.currentZone).toBe('plaza');
     });
 
     it('tracks entity zone correctly for plaza', () => {
-      zoneSystem.updateEntityZone('entity_1', 1472, 1472);
+      zoneSystem.updateEntityZone('entity_1', 736, 736);
 
       expect(zoneSystem.getEntityZone('entity_1')).toBe('plaza');
     });
@@ -76,15 +69,15 @@ describe('ZoneSystem - Plaza Zone (8-zone Grid-Town layout)', () => {
 
   describe('zone population', () => {
     it('returns correct population for plaza zone', () => {
-      zoneSystem.updateEntityZone('entity_1', 1300, 1300);
-      zoneSystem.updateEntityZone('entity_2', 1400, 1400);
+      zoneSystem.updateEntityZone('entity_1', 700, 700);
+      zoneSystem.updateEntityZone('entity_2', 750, 750);
 
       expect(zoneSystem.getZonePopulation('plaza')).toBe(2);
     });
 
     it('returns entities in plaza zone', () => {
-      zoneSystem.updateEntityZone('entity_1', 1300, 1300);
-      zoneSystem.updateEntityZone('entity_2', 1400, 1400);
+      zoneSystem.updateEntityZone('entity_1', 700, 700);
+      zoneSystem.updateEntityZone('entity_2', 750, 750);
 
       const entities = zoneSystem.getEntitiesInZone('plaza');
 
@@ -106,7 +99,7 @@ describe('ZoneSystem - Plaza Zone (8-zone Grid-Town layout)', () => {
     it('returns correct bounds for plaza zone', () => {
       const bounds = zoneSystem.getZoneBounds('plaza');
 
-      expect(bounds).toEqual({ x: 1216, y: 1216, width: 512, height: 512 });
+      expect(bounds).toEqual({ x: 608, y: 608, width: 256, height: 256 });
     });
   });
 });

--- a/tests/unit/zone-transition.test.ts
+++ b/tests/unit/zone-transition.test.ts
@@ -25,120 +25,121 @@ describe('ZoneSystem (8-zone Grid-Town layout)', () => {
   });
 
   describe('getZoneAtPosition', () => {
-    it('returns lobby for position in lobby bounds', () => {
-      expect(zoneSystem.getZoneAtPosition(384, 256)).toBe('lobby');
+    it('returns plaza for position in plaza bounds', () => {
+      expect(zoneSystem.getZoneAtPosition(736, 736)).toBe('plaza');
     });
 
     it('returns office for position in office bounds', () => {
-      expect(zoneSystem.getZoneAtPosition(1664, 288)).toBe('office');
-    });
-
-    it('returns central-park for position in central-park bounds', () => {
-      expect(zoneSystem.getZoneAtPosition(1024, 832)).toBe('central-park');
-    });
-
-    it('returns arcade for position in arcade bounds', () => {
-      expect(zoneSystem.getZoneAtPosition(1696, 768)).toBe('arcade');
+      expect(zoneSystem.getZoneAtPosition(832, 144)).toBe('office');
     });
 
     it('returns meeting for position in meeting bounds', () => {
-      expect(zoneSystem.getZoneAtPosition(320, 1184)).toBe('meeting');
+      expect(zoneSystem.getZoneAtPosition(160, 592)).toBe('meeting');
+    });
+
+    it('returns arcade for position in arcade bounds', () => {
+      expect(zoneSystem.getZoneAtPosition(848, 384)).toBe('arcade');
     });
 
     it('returns lounge-cafe for position in lounge-cafe bounds', () => {
-      expect(zoneSystem.getZoneAtPosition(896, 1440)).toBe('lounge-cafe');
-    });
-
-    it('returns plaza for position in plaza bounds', () => {
-      expect(zoneSystem.getZoneAtPosition(1472, 1472)).toBe('plaza');
+      expect(zoneSystem.getZoneAtPosition(448, 720)).toBe('lounge-cafe');
     });
 
     it('returns lake for position in lake bounds', () => {
-      expect(zoneSystem.getZoneAtPosition(128, 288)).toBe('lake');
+      expect(zoneSystem.getZoneAtPosition(64, 144)).toBe('lake');
+    });
+
+    it('returns lobby for position in lobby bounds', () => {
+      expect(zoneSystem.getZoneAtPosition(192, 128)).toBe('lobby');
+    });
+
+    it('returns central-park for position in central-park bounds', () => {
+      expect(zoneSystem.getZoneAtPosition(512, 416)).toBe('central-park');
     });
 
     it('returns null for position outside all zones', () => {
       expect(zoneSystem.getZoneAtPosition(-100, -100)).toBeNull();
-      expect(zoneSystem.getZoneAtPosition(5000, 5000)).toBeNull();
+      expect(zoneSystem.getZoneAtPosition(2500, 2500)).toBeNull();
     });
 
     it('returns correct zone at zone boundaries', () => {
-      expect(zoneSystem.getZoneAtPosition(192, 64)).toBe('lobby');
-      expect(zoneSystem.getZoneAtPosition(1344, 64)).toBe('office');
-      expect(zoneSystem.getZoneAtPosition(640, 512)).toBe('central-park');
-      expect(zoneSystem.getZoneAtPosition(1408, 512)).toBe('arcade');
-      expect(zoneSystem.getZoneAtPosition(64, 896)).toBe('meeting');
-      expect(zoneSystem.getZoneAtPosition(576, 1216)).toBe('lounge-cafe');
-      expect(zoneSystem.getZoneAtPosition(1216, 1216)).toBe('plaza');
-      expect(zoneSystem.getZoneAtPosition(64, 64)).toBe('lake');
+      expect(zoneSystem.getZoneAtPosition(608, 608)).toBe('plaza');
+      expect(zoneSystem.getZoneAtPosition(863, 863)).toBe('plaza');
+      expect(zoneSystem.getZoneAtPosition(672, 32)).toBe('office');
+      expect(zoneSystem.getZoneAtPosition(32, 448)).toBe('meeting');
+      expect(zoneSystem.getZoneAtPosition(704, 256)).toBe('arcade');
+      expect(zoneSystem.getZoneAtPosition(288, 608)).toBe('lounge-cafe');
+      expect(zoneSystem.getZoneAtPosition(32, 32)).toBe('lake');
+      expect(zoneSystem.getZoneAtPosition(96, 32)).toBe('lobby');
+      expect(zoneSystem.getZoneAtPosition(320, 256)).toBe('central-park');
     });
   });
 
   describe('updateEntityZone', () => {
     it('detects initial zone entry', () => {
-      const result = zoneSystem.updateEntityZone('entity_1', 1024, 832);
+      const result = zoneSystem.updateEntityZone('entity_1', 736, 736);
 
       expect(result.previousZone).toBeNull();
-      expect(result.currentZone).toBe('central-park');
+      expect(result.currentZone).toBe('plaza');
       expect(result.changed).toBe(true);
     });
 
     it('detects no change when entity stays in same zone', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 832);
-      const result = zoneSystem.updateEntityZone('entity_1', 1050, 850);
+      zoneSystem.updateEntityZone('entity_1', 736, 736);
+      const result = zoneSystem.updateEntityZone('entity_1', 750, 750);
 
-      expect(result.previousZone).toBe('central-park');
-      expect(result.currentZone).toBe('central-park');
+      expect(result.previousZone).toBe('plaza');
+      expect(result.currentZone).toBe('plaza');
       expect(result.changed).toBe(false);
     });
 
-    it('detects zone transition from central-park to arcade', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 700);
-      const result = zoneSystem.updateEntityZone('entity_1', 1500, 700);
+    it('detects zone transition from plaza to office', () => {
+      zoneSystem.updateEntityZone('entity_1', 640, 640);
+      const result = zoneSystem.updateEntityZone('entity_1', 832, 144);
 
-      expect(result.previousZone).toBe('central-park');
-      expect(result.currentZone).toBe('arcade');
+      expect(result.previousZone).toBe('plaza');
+      expect(result.currentZone).toBe('office');
       expect(result.changed).toBe(true);
     });
 
     it('emits zone.exit and zone.enter events on transition', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 832, eventLog, 'room_1');
-      zoneSystem.updateEntityZone('entity_1', 1500, 700, eventLog, 'room_1');
+      zoneSystem.updateEntityZone('entity_1', 736, 736, eventLog, 'room_1');
+      zoneSystem.updateEntityZone('entity_1', 832, 144, eventLog, 'room_1');
 
       const { events } = eventLog.getSince('', 10);
 
       expect(events).toHaveLength(3);
 
-      const enterCentralPark = events.find(
-        e => e.type === 'zone.enter' && (e.payload as ZoneEventPayload).zoneId === 'central-park'
+      const enterPlaza = events.find(
+        e => e.type === 'zone.enter' && (e.payload as ZoneEventPayload).zoneId === 'plaza'
       );
-      const exitCentralPark = events.find(
-        e => e.type === 'zone.exit' && (e.payload as ZoneEventPayload).zoneId === 'central-park'
+      const exitPlaza = events.find(
+        e => e.type === 'zone.exit' && (e.payload as ZoneEventPayload).zoneId === 'plaza'
       );
-      const enterArcade = events.find(
-        e => e.type === 'zone.enter' && (e.payload as ZoneEventPayload).zoneId === 'arcade'
+      const enterOffice = events.find(
+        e => e.type === 'zone.enter' && (e.payload as ZoneEventPayload).zoneId === 'office'
       );
 
-      expect(enterCentralPark).toBeDefined();
-      expect(exitCentralPark).toBeDefined();
-      expect(enterArcade).toBeDefined();
-      expect((exitCentralPark?.payload as ZoneEventPayload).nextZoneId).toBe('arcade');
-      expect((enterArcade?.payload as ZoneEventPayload).previousZoneId).toBe('central-park');
+      expect(enterPlaza).toBeDefined();
+      expect(exitPlaza).toBeDefined();
+      expect(enterOffice).toBeDefined();
+      expect((exitPlaza?.payload as ZoneEventPayload).nextZoneId).toBe('office');
+      expect((enterOffice?.payload as ZoneEventPayload).previousZoneId).toBe('plaza');
     });
 
     it('updates entity currentZone when entity provided', () => {
       const entity = new EntitySchema('entity_1', 'human', 'Test', 'room_1');
 
-      zoneSystem.updateEntityZone('entity_1', 1664, 288, eventLog, 'room_1', entity);
+      zoneSystem.updateEntityZone('entity_1', 832, 144, eventLog, 'room_1', entity);
 
       expect(entity.currentZone).toBe('office');
     });
 
     it('handles transition to outside all zones', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 832);
+      zoneSystem.updateEntityZone('entity_1', 736, 736);
       const result = zoneSystem.updateEntityZone('entity_1', -100, -100);
 
-      expect(result.previousZone).toBe('central-park');
+      expect(result.previousZone).toBe('plaza');
       expect(result.currentZone).toBeNull();
       expect(result.changed).toBe(true);
     });
@@ -146,42 +147,42 @@ describe('ZoneSystem (8-zone Grid-Town layout)', () => {
 
   describe('getZonePopulation', () => {
     it('returns 0 for empty zone', () => {
-      expect(zoneSystem.getZonePopulation('central-park')).toBe(0);
+      expect(zoneSystem.getZonePopulation('plaza')).toBe(0);
     });
 
     it('increments population when entity enters zone', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 832);
+      zoneSystem.updateEntityZone('entity_1', 736, 736);
 
-      expect(zoneSystem.getZonePopulation('central-park')).toBe(1);
+      expect(zoneSystem.getZonePopulation('plaza')).toBe(1);
     });
 
     it('decrements population when entity leaves zone', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 832);
-      zoneSystem.updateEntityZone('entity_1', 1500, 700);
+      zoneSystem.updateEntityZone('entity_1', 736, 736);
+      zoneSystem.updateEntityZone('entity_1', 832, 144);
 
-      expect(zoneSystem.getZonePopulation('central-park')).toBe(0);
-      expect(zoneSystem.getZonePopulation('arcade')).toBe(1);
+      expect(zoneSystem.getZonePopulation('plaza')).toBe(0);
+      expect(zoneSystem.getZonePopulation('office')).toBe(1);
     });
 
     it('tracks multiple entities per zone', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 832);
-      zoneSystem.updateEntityZone('entity_2', 1050, 850);
-      zoneSystem.updateEntityZone('entity_3', 1100, 900);
+      zoneSystem.updateEntityZone('entity_1', 736, 736);
+      zoneSystem.updateEntityZone('entity_2', 750, 750);
+      zoneSystem.updateEntityZone('entity_3', 800, 800);
 
-      expect(zoneSystem.getZonePopulation('central-park')).toBe(3);
+      expect(zoneSystem.getZonePopulation('plaza')).toBe(3);
     });
   });
 
   describe('getEntitiesInZone', () => {
     it('returns empty array for zone with no entities', () => {
-      expect(zoneSystem.getEntitiesInZone('central-park')).toEqual([]);
+      expect(zoneSystem.getEntitiesInZone('plaza')).toEqual([]);
     });
 
     it('returns entity IDs in zone', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 832);
-      zoneSystem.updateEntityZone('entity_2', 1050, 850);
+      zoneSystem.updateEntityZone('entity_1', 736, 736);
+      zoneSystem.updateEntityZone('entity_2', 750, 750);
 
-      const entities = zoneSystem.getEntitiesInZone('central-park');
+      const entities = zoneSystem.getEntitiesInZone('plaza');
 
       expect(entities).toHaveLength(2);
       expect(entities).toContain('entity_1');
@@ -189,21 +190,21 @@ describe('ZoneSystem (8-zone Grid-Town layout)', () => {
     });
 
     it('excludes entities that left zone', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 832);
-      zoneSystem.updateEntityZone('entity_1', 1500, 700);
+      zoneSystem.updateEntityZone('entity_1', 736, 736);
+      zoneSystem.updateEntityZone('entity_1', 832, 144);
 
-      expect(zoneSystem.getEntitiesInZone('central-park')).toEqual([]);
-      expect(zoneSystem.getEntitiesInZone('arcade')).toContain('entity_1');
+      expect(zoneSystem.getEntitiesInZone('plaza')).toEqual([]);
+      expect(zoneSystem.getEntitiesInZone('office')).toContain('entity_1');
     });
   });
 
   describe('removeEntity', () => {
     it('returns previous zone when entity removed', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 832);
+      zoneSystem.updateEntityZone('entity_1', 736, 736);
 
       const previousZone = zoneSystem.removeEntity('entity_1');
 
-      expect(previousZone).toBe('central-park');
+      expect(previousZone).toBe('plaza');
     });
 
     it('returns null when entity was not tracked', () => {
@@ -213,26 +214,26 @@ describe('ZoneSystem (8-zone Grid-Town layout)', () => {
     });
 
     it('decrements population when entity removed', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 832);
-      zoneSystem.updateEntityZone('entity_2', 1050, 850);
+      zoneSystem.updateEntityZone('entity_1', 736, 736);
+      zoneSystem.updateEntityZone('entity_2', 750, 750);
 
-      expect(zoneSystem.getZonePopulation('central-park')).toBe(2);
+      expect(zoneSystem.getZonePopulation('plaza')).toBe(2);
 
       zoneSystem.removeEntity('entity_1');
 
-      expect(zoneSystem.getZonePopulation('central-park')).toBe(1);
+      expect(zoneSystem.getZonePopulation('plaza')).toBe(1);
     });
 
     it('removes entity from tracking', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 832);
+      zoneSystem.updateEntityZone('entity_1', 736, 736);
       zoneSystem.removeEntity('entity_1');
 
       expect(zoneSystem.getEntityZone('entity_1')).toBeNull();
-      expect(zoneSystem.getEntitiesInZone('central-park')).not.toContain('entity_1');
+      expect(zoneSystem.getEntitiesInZone('plaza')).not.toContain('entity_1');
     });
 
     it('emits zone.exit event with null nextZoneId', () => {
-      zoneSystem.updateEntityZone('entity_1', 1024, 832, eventLog, 'room_1');
+      zoneSystem.updateEntityZone('entity_1', 736, 736, eventLog, 'room_1');
       zoneSystem.removeEntity('entity_1', eventLog, 'room_1');
 
       const { events } = eventLog.getSince('', 10);
@@ -244,7 +245,7 @@ describe('ZoneSystem (8-zone Grid-Town layout)', () => {
       );
 
       expect(exitEvent).toBeDefined();
-      expect((exitEvent?.payload as ZoneEventPayload).zoneId).toBe('central-park');
+      expect((exitEvent?.payload as ZoneEventPayload).zoneId).toBe('plaza');
     });
   });
 
@@ -254,33 +255,33 @@ describe('ZoneSystem (8-zone Grid-Town layout)', () => {
       const entity1 = new EntitySchema('entity_1', 'human', 'Test1', 'room_1');
       const entity2 = new EntitySchema('entity_2', 'human', 'Test2', 'room_1');
 
-      entity1.setPosition(1024, 832);
-      entity2.setPosition(1664, 288);
+      entity1.setPosition(736, 736);
+      entity2.setPosition(832, 144);
       entities.set('entity_1', entity1);
       entities.set('entity_2', entity2);
 
       const zoneEvents = zoneSystem.update(entities, eventLog, 'room_1');
 
       expect(zoneEvents).toHaveLength(2);
-      expect(entity1.currentZone).toBe('central-park');
+      expect(entity1.currentZone).toBe('plaza');
       expect(entity2.currentZone).toBe('office');
-      expect(zoneSystem.getZonePopulation('central-park')).toBe(1);
+      expect(zoneSystem.getZonePopulation('plaza')).toBe(1);
       expect(zoneSystem.getZonePopulation('office')).toBe(1);
     });
 
     it('cleans up removed entities', () => {
       const entities = new Map<string, EntitySchema>();
       const entity1 = new EntitySchema('entity_1', 'human', 'Test1', 'room_1');
-      entity1.setPosition(1024, 832);
+      entity1.setPosition(736, 736);
       entities.set('entity_1', entity1);
 
       zoneSystem.update(entities, eventLog, 'room_1');
-      expect(zoneSystem.getZonePopulation('central-park')).toBe(1);
+      expect(zoneSystem.getZonePopulation('plaza')).toBe(1);
 
       entities.delete('entity_1');
       zoneSystem.update(entities, eventLog, 'room_1');
 
-      expect(zoneSystem.getZonePopulation('central-park')).toBe(0);
+      expect(zoneSystem.getZonePopulation('plaza')).toBe(0);
       expect(zoneSystem.getEntityZone('entity_1')).toBeNull();
     });
   });
@@ -288,9 +289,9 @@ describe('ZoneSystem (8-zone Grid-Town layout)', () => {
   describe('edge cases', () => {
     describe('spawn', () => {
       it('handles entity spawning at zone boundary', () => {
-        const result = zoneSystem.updateEntityZone('entity_1', 192, 64);
+        const result = zoneSystem.updateEntityZone('entity_1', 672, 32);
 
-        expect(result.currentZone).toBe('lobby');
+        expect(result.currentZone).toBe('office');
         expect(result.changed).toBe(true);
       });
 
@@ -304,57 +305,58 @@ describe('ZoneSystem (8-zone Grid-Town layout)', () => {
 
     describe('teleport', () => {
       it('handles teleport across multiple zones', () => {
-        zoneSystem.updateEntityZone('entity_1', 1024, 832);
-        const result = zoneSystem.updateEntityZone('entity_1', 128, 288);
+        zoneSystem.updateEntityZone('entity_1', 736, 736);
+        const result = zoneSystem.updateEntityZone('entity_1', 64, 144);
 
-        expect(result.previousZone).toBe('central-park');
+        expect(result.previousZone).toBe('plaza');
         expect(result.currentZone).toBe('lake');
         expect(result.changed).toBe(true);
       });
 
       it('updates populations correctly on teleport', () => {
-        zoneSystem.updateEntityZone('entity_1', 1024, 832);
-        zoneSystem.updateEntityZone('entity_2', 1050, 850);
+        zoneSystem.updateEntityZone('entity_1', 736, 736);
+        zoneSystem.updateEntityZone('entity_2', 750, 750);
 
-        expect(zoneSystem.getZonePopulation('central-park')).toBe(2);
+        expect(zoneSystem.getZonePopulation('plaza')).toBe(2);
 
-        zoneSystem.updateEntityZone('entity_1', 128, 288);
+        zoneSystem.updateEntityZone('entity_1', 64, 144);
 
-        expect(zoneSystem.getZonePopulation('central-park')).toBe(1);
+        expect(zoneSystem.getZonePopulation('plaza')).toBe(1);
         expect(zoneSystem.getZonePopulation('lake')).toBe(1);
       });
     });
 
     describe('boundary precision', () => {
       it('correctly handles positions exactly on zone boundary', () => {
-        expect(zoneSystem.getZoneAtPosition(192, 256)).toBe('lobby');
-        expect(zoneSystem.getZoneAtPosition(191, 256)).toBe('lake');
-        expect(zoneSystem.getZoneAtPosition(63, 256)).toBeNull();
+        expect(zoneSystem.getZoneAtPosition(672, 144)).toBe('office');
+        expect(zoneSystem.getZoneAtPosition(671, 144)).toBeNull();
       });
 
-      it('handles central-park adjacency with lounge-cafe', () => {
-        expect(zoneSystem.getZoneAtPosition(800, 1100)).toBe('central-park');
-        expect(zoneSystem.getZoneAtPosition(800, 1300)).toBe('lounge-cafe');
+      it('handles plaza adjacency with lounge-cafe', () => {
+        expect(zoneSystem.getZoneAtPosition(736, 550)).toBeNull();
+        expect(zoneSystem.getZoneAtPosition(736, 608)).toBe('plaza');
+        expect(zoneSystem.getZoneAtPosition(736, 800)).toBe('plaza');
+        expect(zoneSystem.getZoneAtPosition(550, 736)).toBe('lounge-cafe');
       });
     });
 
     describe('population never goes negative', () => {
       it('population stays at 0 after multiple removes', () => {
-        zoneSystem.updateEntityZone('entity_1', 1024, 832);
+        zoneSystem.updateEntityZone('entity_1', 736, 736);
         zoneSystem.removeEntity('entity_1');
         zoneSystem.removeEntity('entity_1');
         zoneSystem.removeEntity('entity_1');
 
-        expect(zoneSystem.getZonePopulation('central-park')).toBe(0);
+        expect(zoneSystem.getZonePopulation('plaza')).toBe(0);
       });
     });
   });
 
   describe('getZoneBounds', () => {
     it('returns bounds for valid zone', () => {
-      const bounds = zoneSystem.getZoneBounds('central-park');
+      const bounds = zoneSystem.getZoneBounds('plaza');
 
-      expect(bounds).toEqual({ x: 640, y: 512, width: 768, height: 640 });
+      expect(bounds).toEqual({ x: 608, y: 608, width: 256, height: 256 });
     });
 
     it('returns undefined for invalid zone', () => {

--- a/world/packs/base/npcs/arcade-host.json
+++ b/world/packs/base/npcs/arcade-host.json
@@ -3,11 +3,11 @@
   "name": "Drew the Game Master",
   "sprite": "npc-arcade-host",
   "zone": "arcade",
-  "defaultPosition": { "x": 1600, "y": 768 },
+  "defaultPosition": { "x": 800, "y": 384 },
   "schedule": [
-    { "startHour": 10, "endHour": 14, "state": "working", "position": { "x": 1600, "y": 768 } },
-    { "startHour": 14, "endHour": 15, "state": "break", "position": { "x": 800, "y": 1440 } },
-    { "startHour": 15, "endHour": 22, "state": "working", "position": { "x": 1600, "y": 768 } }
+    { "startHour": 10, "endHour": 14, "state": "working", "position": { "x": 800, "y": 384 } },
+    { "startHour": 14, "endHour": 15, "state": "break", "position": { "x": 400, "y": 720 } },
+    { "startHour": 15, "endHour": 22, "state": "working", "position": { "x": 800, "y": 384 } }
   ],
   "dialogue": {
     "greeting": {

--- a/world/packs/base/npcs/barista.json
+++ b/world/packs/base/npcs/barista.json
@@ -3,11 +3,11 @@
   "name": "Jamie the Barista",
   "sprite": "npc-barista",
   "zone": "lounge-cafe",
-  "defaultPosition": { "x": 800, "y": 1440 },
+  "defaultPosition": { "x": 400, "y": 720 },
   "schedule": [
-    { "startHour": 9, "endHour": 12, "state": "working", "position": { "x": 800, "y": 1440 } },
-    { "startHour": 12, "endHour": 13, "state": "break", "position": { "x": 850, "y": 1500 } },
-    { "startHour": 13, "endHour": 18, "state": "working", "position": { "x": 800, "y": 1440 } }
+    { "startHour": 9, "endHour": 12, "state": "working", "position": { "x": 400, "y": 720 } },
+    { "startHour": 12, "endHour": 13, "state": "break", "position": { "x": 425, "y": 750 } },
+    { "startHour": 13, "endHour": 18, "state": "working", "position": { "x": 400, "y": 720 } }
   ],
   "dialogue": {
     "greeting": {

--- a/world/packs/base/npcs/fountain-keeper.json
+++ b/world/packs/base/npcs/fountain-keeper.json
@@ -3,9 +3,9 @@
   "name": "Quinn the Fountain Keeper",
   "sprite": "npc-keeper",
   "zone": "plaza",
-  "defaultPosition": { "x": 1440, "y": 1344 },
+  "defaultPosition": { "x": 720, "y": 672 },
   "schedule": [
-    { "startHour": 6, "endHour": 20, "state": "working", "position": { "x": 1440, "y": 1344 } }
+    { "startHour": 6, "endHour": 20, "state": "working", "position": { "x": 720, "y": 672 } }
   ],
   "dialogue": {
     "greeting": {

--- a/world/packs/base/npcs/greeter.json
+++ b/world/packs/base/npcs/greeter.json
@@ -3,9 +3,9 @@
   "name": "Sam the Greeter",
   "sprite": "npc-greeter",
   "zone": "lobby",
-  "defaultPosition": { "x": 320, "y": 256 },
+  "defaultPosition": { "x": 160, "y": 128 },
   "schedule": [
-    { "startHour": 9, "endHour": 18, "state": "working", "position": { "x": 320, "y": 256 } }
+    { "startHour": 9, "endHour": 18, "state": "working", "position": { "x": 160, "y": 128 } }
   ],
   "dialogue": {
     "greeting": {

--- a/world/packs/base/npcs/it-help.json
+++ b/world/packs/base/npcs/it-help.json
@@ -3,11 +3,10 @@
   "name": "Casey the IT Support",
   "sprite": "npc-it",
   "zone": "office",
-  "defaultPosition": { "x": 1728, "y": 256 },
+  "defaultPosition": { "x": 864, "y": 128 },
   "schedule": [
-    { "startHour": 9, "endHour": 12, "state": "working", "position": { "x": 1728, "y": 256 } },
-    { "startHour": 12, "endHour": 13, "state": "break", "position": { "x": 800, "y": 1440 } },
-    { "startHour": 13, "endHour": 18, "state": "working", "position": { "x": 1728, "y": 256 } }
+    { "startHour": 9, "endHour": 18, "state": "working", "position": { "x": 864, "y": 128 } },
+    { "startHour": 12, "endHour": 13, "state": "break", "position": { "x": 400, "y": 720 } }
   ],
   "dialogue": {
     "greeting": {

--- a/world/packs/base/npcs/meeting-host.json
+++ b/world/packs/base/npcs/meeting-host.json
@@ -3,11 +3,11 @@
   "name": "Alex the Meeting Coordinator",
   "sprite": "npc-meeting-host",
   "zone": "meeting",
-  "defaultPosition": { "x": 288, "y": 1120 },
+  "defaultPosition": { "x": 144, "y": 560 },
   "schedule": [
-    { "startHour": 8, "endHour": 12, "state": "working", "position": { "x": 288, "y": 1120 } },
-    { "startHour": 12, "endHour": 13, "state": "break", "position": { "x": 800, "y": 1440 } },
-    { "startHour": 13, "endHour": 18, "state": "working", "position": { "x": 288, "y": 1120 } }
+    { "startHour": 8, "endHour": 12, "state": "working", "position": { "x": 144, "y": 560 } },
+    { "startHour": 12, "endHour": 13, "state": "break", "position": { "x": 400, "y": 720 } },
+    { "startHour": 13, "endHour": 18, "state": "working", "position": { "x": 144, "y": 560 } }
   ],
   "dialogue": {
     "greeting": {

--- a/world/packs/base/npcs/office-pm.json
+++ b/world/packs/base/npcs/office-pm.json
@@ -3,11 +3,11 @@
   "name": "Jordan the PM",
   "sprite": "npc-pm",
   "zone": "office",
-  "defaultPosition": { "x": 1600, "y": 320 },
+  "defaultPosition": { "x": 800, "y": 160 },
   "schedule": [
-    { "startHour": 9, "endHour": 12, "state": "working", "position": { "x": 1600, "y": 320 } },
-    { "startHour": 12, "endHour": 13, "state": "break", "position": { "x": 800, "y": 1440 } },
-    { "startHour": 13, "endHour": 18, "state": "working", "position": { "x": 1600, "y": 320 } }
+    { "startHour": 9, "endHour": 12, "state": "working", "position": { "x": 800, "y": 160 } },
+    { "startHour": 12, "endHour": 13, "state": "break", "position": { "x": 400, "y": 720 } },
+    { "startHour": 13, "endHour": 18, "state": "working", "position": { "x": 800, "y": 160 } }
   ],
   "dialogue": {
     "greeting": {

--- a/world/packs/base/npcs/ranger.json
+++ b/world/packs/base/npcs/ranger.json
@@ -3,9 +3,9 @@
   "name": "River the Ranger",
   "sprite": "npc-ranger",
   "zone": "central-park",
-  "defaultPosition": { "x": 1024, "y": 800 },
+  "defaultPosition": { "x": 512, "y": 400 },
   "schedule": [
-    { "startHour": 6, "endHour": 18, "state": "patrolling", "position": { "x": 1024, "y": 800 } }
+    { "startHour": 6, "endHour": 18, "state": "patrolling", "position": { "x": 512, "y": 400 } }
   ],
   "dialogue": {
     "greeting": {

--- a/world/packs/base/npcs/security.json
+++ b/world/packs/base/npcs/security.json
@@ -3,9 +3,9 @@
   "name": "Max the Guard",
   "sprite": "npc-security",
   "zone": "lobby",
-  "defaultPosition": { "x": 384, "y": 192 },
+  "defaultPosition": { "x": 192, "y": 96 },
   "schedule": [
-    { "startHour": 0, "endHour": 24, "state": "working", "position": { "x": 384, "y": 192 } }
+    { "startHour": 0, "endHour": 24, "state": "working", "position": { "x": 192, "y": 96 } }
   ],
   "dialogue": {
     "greeting": {


### PR DESCRIPTION
## Summary

Migrates the entire tile system from 32×32 to 16×16 native tile sizes, enabling native use of Kenney 1-Bit Pack assets without scaling.

## Changes

- **World dimensions**: 2048×2048 → 1024×1024 pixels
- **Tile size**: 32px → 16px (tile count remains 64×64)
- **Zone bounds**: All 8 zones halved to new coordinates
- **NPC positions**: All 9 NPCs repositioned for new scale
- **Client systems**: Updated rendering, collision, and minimap

## New Zone Bounds (16×16)

| Zone | Bounds (x, y, width, height) |
|------|------------------------------|
| lobby | (96, 32, 192, 192) |
| office | (672, 32, 320, 224) |
| central-park | (320, 256, 384, 320) |
| arcade | (704, 256, 288, 256) |
| meeting | (32, 448, 256, 288) |
| lounge-cafe | (288, 608, 320, 224) |
| plaza | (608, 608, 256, 256) |
| lake | (32, 32, 64, 224) |

## Files Modified (22 files)

**Core Systems:**
- `packages/shared/src/world.ts` - ZONE_BOUNDS, tileSize, pixelWidth/Height
- `packages/server/src/constants.ts` - DEFAULT_TILE_SIZE, DEFAULT_SPAWN_POSITION
- `packages/server/src/world/WorldPackLoader.ts` - fallback bounds

**Client:**
- `packages/client/src/game/scenes/GameScene.ts` - rendering constants
- `packages/client/src/ui/Minimap.ts` - tile size multipliers
- `packages/client/src/world/TileInterpreter.ts` - default params
- `packages/client/src/systems/CollisionSystem.ts` - default params
- `packages/client/public/assets/maps/tileset.json` - tilewidth/height

**NPCs (9 files):**
- All NPC position files halved

**Tests (6 files):**
- Zone system tests updated with new 16×16 coordinates
- All 971 tests pass

## Testing

- ✅ `pnpm build` - Successful
- ✅ `pnpm test` - All 971 tests pass
- ✅ Merge conflicts from main resolved

## Next Steps (Epic 2: Kenney Asset Integration)

After this PR is merged:
- #87: Asset extraction from Kenney 1-Bit Pack
- #88: Tileset migration SVG→PNG
- #89: NPC sprites
- #91: Object sprites
- #94: Player sprites