### PR TITLE
refactor: replace deep relative import with path alias and add Zod validation for tileset

### DIFF
--- a/packages/client/src/world/TileInterpreter.ts
+++ b/packages/client/src/world/TileInterpreter.ts
@@ -1,12 +1,12 @@
 import type {
   TileInfo,
   TileType,
-  TilesetDefinition,
   TilesetTileDefinition,
   WorldGrid,
   ZoneId,
 } from '@openclawworld/shared';
-import villageTileset from '../../../../world/packs/base/assets/tilesets/village_tileset.json';
+import { TilesetDefinitionSchema } from '@openclawworld/shared';
+import villageTilesetJson from '@world/packs/base/assets/tilesets/village_tileset.json';
 
 type ColorRange = {
   r: [number, number];
@@ -42,7 +42,7 @@ const ZONE_FLOOR_TYPES: Map<TileType, ZoneId> = new Map([
   ['floor_lake', 'lake'],
 ]);
 
-const tileset: TilesetDefinition = villageTileset as TilesetDefinition;
+const tileset = TilesetDefinitionSchema.parse(villageTilesetJson);
 const tileDefById: Map<number, TilesetTileDefinition> = new Map(tileset.tiles.map(t => [t.id, t]));
 
 export class TileInterpreter {

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -11,7 +11,12 @@
     "useDefineForClassFields": false,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "noEmit": true
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@world/*": ["../../world/*"]
+    }
   },
   "include": ["src/**/*", "../server/src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.ts"]

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
+import { resolve } from 'path';
 
 export default defineConfig({
   server: {
     port: 5173,
+  },
+  resolve: {
+    alias: {
+      '@world': resolve(__dirname, '../../world'),
+    },
   },
   build: {
     outDir: 'dist',

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -680,3 +680,41 @@ export const WorkLifeEventTypeSchema = z.enum([
   'npc.dialogue',
   'facility.interact',
 ]);
+
+// ============================================================================
+// Tileset Schemas
+// ============================================================================
+
+export const TileTypeSchema = z.enum([
+  'empty',
+  'grass',
+  'road',
+  'floor_lobby',
+  'floor_office',
+  'floor_meeting',
+  'floor_lounge',
+  'floor_arcade',
+  'floor_plaza',
+  'floor_lake',
+  'door',
+  'wall',
+  'water',
+  'decoration',
+]);
+
+export const TilesetTileDefinitionSchema = z.object({
+  id: z.number().int().min(0),
+  type: TileTypeSchema,
+  collision: z.boolean(),
+  isDoor: z.boolean().optional(),
+});
+
+export const TilesetDefinitionSchema = z.object({
+  name: z.string().min(1).max(64),
+  tilewidth: z.number().int().min(1),
+  tileheight: z.number().int().min(1),
+  tilecount: z.number().int().min(1),
+  columns: z.number().int().min(1),
+  license: z.string().optional(),
+  tiles: z.array(TilesetTileDefinitionSchema).min(1),
+});


### PR DESCRIPTION
## Summary

Addresses CodeRabbit nitpicks from PR #111:
- Replaces fragile deep relative imports with path aliases
- Adds runtime validation for tileset JSON using Zod schemas

## Changes

### Path Alias Configuration (#113)
- Added `@world/*` path alias in `packages/client/tsconfig.json`
- Added resolve alias in `packages/client/vite.config.ts`
- Replaced `../../../../world/...` import with `@world/...` in TileInterpreter.ts

### Zod Runtime Validation (#114)
- Added `TileTypeSchema` enum to shared schemas
- Added `TilesetTileDefinitionSchema` for individual tile definitions
- Added `TilesetDefinitionSchema` for complete tileset validation
- Replaced type assertion (`as TilesetDefinition`) with `TilesetDefinitionSchema.parse()` for runtime safety

## Testing

- All 992 tests pass
- Typecheck passes
- Build succeeds

## Closes

Closes #113
Closes #114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 타일셋 데이터 검증 체계를 강화하여 로드 시 런타임 검증을 실시하도록 개선했습니다.
  * 개발 환경 설정을 최적화하여 모듈 해석 및 경로 별칭 기능을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->