### PR TITLE
fix: align WorldPackLoader unified-map fallbacks with 64x64@16 (#232)

### DIFF
--- a/tests/unit/world-pack.test.ts
+++ b/tests/unit/world-pack.test.ts
@@ -8,7 +8,7 @@ import {
   type PackManifest,
 } from '../../packages/server/src/world/WorldPackLoader.js';
 import { MapLoader } from '../../packages/server/src/map/MapLoader.js';
-import type { ZoneId } from '@openclawworld/shared';
+import { MAP_CONFIG, type ZoneId } from '@openclawworld/shared';
 
 const TEST_PACK_PATH = resolve(process.cwd(), 'tests/fixtures/test-pack');
 const REAL_PACK_PATH = resolve(process.cwd(), 'world/packs/base');
@@ -288,7 +288,9 @@ describe('WorldPackLoader', () => {
       expect(plaza).toBeDefined();
       expect(plaza?.name).toBe('Plaza');
     });
+  });
 
+  describe('unified map fallback', () => {
     it('uses MAP_CONFIG defaults for unified map dimensions when metadata is missing', () => {
       createTestPack({
         zones: ['plaza'],
@@ -303,10 +305,27 @@ describe('WorldPackLoader', () => {
 
       const plaza = loader.getZoneMap('plaza');
       expect(plaza).toBeDefined();
-      expect(plaza?.width).toBe(64);
-      expect(plaza?.height).toBe(64);
-      expect(plaza?.tileWidth).toBe(16);
-      expect(plaza?.tileHeight).toBe(16);
+      expect(plaza?.width).toBe(MAP_CONFIG.width);
+      expect(plaza?.height).toBe(MAP_CONFIG.height);
+      expect(plaza?.tileWidth).toBe(MAP_CONFIG.tileSize);
+      expect(plaza?.tileHeight).toBe(MAP_CONFIG.tileSize);
+    });
+
+    it('throws WorldPackError for invalid unified map dimensions', () => {
+      createTestPack({
+        zones: ['plaza'],
+        skipMaps: true,
+        unifiedMap: {
+          width: -1,
+          height: 64,
+          tilewidth: 16,
+          tileheight: 16,
+          layers: [],
+        },
+      });
+
+      const loader = new WorldPackLoader(TEST_PACK_PATH);
+      expect(() => loader.loadPack()).toThrow(WorldPackError);
     });
   });
 });


### PR DESCRIPTION
## Summary
- align `WorldPackLoader` unified-map fallback values to shared `MAP_CONFIG` instead of hardcoded `height: 52`
- reuse resolved fallback values for width/height/tile size so map payload and logs stay consistent
- add regression test proving unified maps without dimension metadata default to `64x64` and `16px` tile size

## Why
Issue #232 tracks a contract mismatch where unified-map fallback dimensions diverged from the current 64x64@16 world contract.

## Changes
- `packages/server/src/world/WorldPackLoader.ts`
- `tests/unit/world-pack.test.ts`

## Validation
- `pnpm --filter @openclawworld/shared build`
- `pnpm generate:tools`
- `pnpm generate:commands`
- `pnpm format`
- codegen drift check (`git status --porcelain ...` target paths)
- `pnpm lint`
- `pnpm format:check`
- `pnpm -r build`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test -- --coverage`
- `pnpm verify:maps`

Closes #232


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 맵 구성 설정이 더 일관된 방식으로 처리되도록 개선되었습니다.

* **Tests**
  * 맵 기본 설정이 올바르게 적용되는지 확인하는 테스트 커버리지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->