### PR TITLE
ci: Add PR template and CODEOWNERS for review enforcement (#245, #247)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,101 @@
+# CODEOWNERS for openClawWorld
+# These owners will be requested for review when someone opens a PR
+# that modifies code they own.
+#
+# Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything
+* @Two-Weeks-Team/maintainers
+
+# =============================================================================
+# MAP STACK (Critical - requires careful review)
+# =============================================================================
+
+# Map source files (single source of truth)
+world/packs/base/maps/ @Two-Weeks-Team/map-reviewers @Two-Weeks-Team/maintainers
+
+# Map sync targets (should only change via sync script)
+packages/server/assets/maps/ @Two-Weeks-Team/map-reviewers @Two-Weeks-Team/maintainers
+packages/client/public/assets/maps/ @Two-Weeks-Team/map-reviewers @Two-Weeks-Team/maintainers
+
+# Map sync and verification scripts
+scripts/sync-maps.mjs @Two-Weeks-Team/map-reviewers @Two-Weeks-Team/maintainers
+scripts/sync-maps.sh @Two-Weeks-Team/map-reviewers @Two-Weeks-Team/maintainers
+scripts/verify-map-stack-consistency.mjs @Two-Weeks-Team/map-reviewers @Two-Weeks-Team/maintainers
+
+# =============================================================================
+# ASSET PIPELINE (Kenney assets, extraction tools)
+# =============================================================================
+
+# Kenney curation manifest
+tools/kenney-curation.json @Two-Weeks-Team/asset-reviewers @Two-Weeks-Team/maintainers
+
+# Asset extraction scripts
+tools/extract_*.py @Two-Weeks-Team/asset-reviewers @Two-Weeks-Team/maintainers
+tools/generate_*.py @Two-Weeks-Team/asset-reviewers @Two-Weeks-Team/maintainers
+tools/sprites/ @Two-Weeks-Team/asset-reviewers @Two-Weeks-Team/maintainers
+
+# =============================================================================
+# WORLD DATA (NPCs, Facilities, Zones)
+# =============================================================================
+
+# NPC definitions
+world/packs/base/npcs/ @Two-Weeks-Team/map-reviewers @Two-Weeks-Team/maintainers
+
+# Facility definitions
+world/packs/base/facilities/ @Two-Weeks-Team/map-reviewers @Two-Weeks-Team/maintainers
+
+# World type definitions
+packages/shared/src/world.ts @Two-Weeks-Team/map-reviewers @Two-Weeks-Team/maintainers
+
+# =============================================================================
+# SERVER CORE (Game logic, AIC handlers)
+# =============================================================================
+
+# World loading and zone management
+packages/server/src/world/ @Two-Weeks-Team/server-reviewers @Two-Weeks-Team/maintainers
+packages/server/src/zone/ @Two-Weeks-Team/server-reviewers @Two-Weeks-Team/maintainers
+
+# AIC API handlers
+packages/server/src/aic/ @Two-Weeks-Team/server-reviewers @Two-Weeks-Team/maintainers
+
+# Game rooms
+packages/server/src/rooms/ @Two-Weeks-Team/server-reviewers @Two-Weeks-Team/maintainers
+
+# =============================================================================
+# CLIENT CORE (Game scenes, UI)
+# =============================================================================
+
+# Game scenes
+packages/client/src/game/scenes/ @Two-Weeks-Team/client-reviewers @Two-Weeks-Team/maintainers
+
+# UI components
+packages/client/src/ui/ @Two-Weeks-Team/client-reviewers @Two-Weeks-Team/maintainers
+
+# =============================================================================
+# CI/CD AND CONFIGURATION
+# =============================================================================
+
+# GitHub workflows
+.github/workflows/ @Two-Weeks-Team/maintainers
+
+# GitHub templates and config
+.github/CODEOWNERS @Two-Weeks-Team/maintainers
+.github/pull_request_template.md @Two-Weeks-Team/maintainers
+
+# Package configuration
+package.json @Two-Weeks-Team/maintainers
+pnpm-workspace.yaml @Two-Weeks-Team/maintainers
+tsconfig*.json @Two-Weeks-Team/maintainers
+
+# =============================================================================
+# DOCUMENTATION
+# =============================================================================
+
+# Reference documentation
+docs/reference/ @Two-Weeks-Team/maintainers
+docs/templates/ @Two-Weeks-Team/maintainers
+
+# Main README
+README.md @Two-Weeks-Team/maintainers
+AGENTS.md @Two-Weeks-Team/maintainers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,80 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Related Issues
+
+<!-- Link related issues using "Fixes #123" or "Closes #123" syntax -->
+
+---
+
+## Checklist
+
+### General
+
+- [ ] Code follows project conventions
+- [ ] Self-reviewed the changes
+- [ ] No new TypeScript errors introduced
+- [ ] Tests pass locally (`pnpm test`)
+
+### Map Changes (if applicable)
+
+> Complete this section if your PR affects any map-related files:
+>
+> - `world/packs/base/maps/*.json`
+> - `packages/server/assets/maps/*.json`
+> - `packages/client/public/assets/maps/*.json`
+> - `packages/shared/src/world.ts`
+> - `packages/server/src/world/WorldPackLoader.ts`
+> - `tools/kenney-curation.json`
+> - `tools/extract_*.py`
+> - `world/packs/base/npcs/*.json`
+
+- [ ] **Not applicable** (no map-related changes)
+
+<details>
+<summary>Map Change Checklist (expand if applicable)</summary>
+
+#### Verification Commands
+
+- [ ] `pnpm sync-maps` executed
+- [ ] `node scripts/verify-map-stack-consistency.mjs` passes
+- [ ] `pnpm build` succeeds
+- [ ] `pnpm test` passes
+
+#### Contract Checks
+
+- [ ] Map source/server/client hashes match
+- [ ] Tile size (16x16) contract maintained
+- [ ] Spawn coordinates within valid bounds
+- [ ] Collision layer values are 0 or 1 only
+- [ ] NPC IDs match atlas frame keys
+- [ ] No hardcoded zone/coordinate values added
+
+#### Documentation
+
+- [ ] Evidence provided using [template](docs/templates/map-change-evidence.md)
+- [ ] README links verified (if applicable)
+- [ ] Map-related docs updated (if applicable)
+
+</details>
+
+---
+
+## Verification
+
+```bash
+# Paste verification output here
+pnpm typecheck    # Result:
+pnpm lint         # Result:
+pnpm build        # Result:
+pnpm test         # Result:
+```
+
+## Screenshots (if applicable)
+
+<!-- Add screenshots for UI changes -->
+
+## Additional Notes
+
+<!-- Any additional context for reviewers -->


### PR DESCRIPTION
## Summary

This PR introduces PR safety guardrails to enforce consistent review practices:

- **Fix #245**: PR template with map change checklist for standardized submissions
- **Fix #247**: CODEOWNERS file for mandatory reviews on critical code paths

## Changes

| File | Description |
|------|-------------|
| `.github/pull_request_template.md` | PR template with general checklist and expandable map-specific section |
| `.github/CODEOWNERS` | Review ownership assignments for all critical paths |

## CODEOWNERS Coverage

| Path | Owners |
|------|--------|
| `world/packs/base/maps/` | map-reviewers, maintainers |
| `packages/*/assets/maps/` | map-reviewers, maintainers |
| `tools/kenney-curation.json` | asset-reviewers, maintainers |
| `tools/extract_*.py` | asset-reviewers, maintainers |
| `packages/server/src/aic/` | server-reviewers, maintainers |
| `packages/client/src/game/` | client-reviewers, maintainers |
| `.github/workflows/` | maintainers |

## Verification

```bash
pnpm typecheck    # ✅ Pass
pnpm lint         # ✅ Pass  
pnpm test         # ✅ 994 tests passed
```

## Checklist

- [x] Configuration files only (no code changes)
- [x] All verification commands pass
- [x] PR template includes map change checklist
- [x] CODEOWNERS covers all critical paths

## Note

The teams referenced in CODEOWNERS (`@Two-Weeks-Team/maintainers`, `@Two-Weeks-Team/map-reviewers`, etc.) need to be created in the GitHub organization settings for the review enforcement to work.