### PR TITLE
chore: Document tileset manifest contract (#233)

### DIFF
--- a/tools/kenney-curation.json
+++ b/tools/kenney-curation.json
@@ -3,6 +3,12 @@
   "version": "1.0.0",
   "generated": "2025-02-13",
   "description": "Kenney asset curation manifest for openClawWorld. All coordinates are 0-indexed (col, row).",
+  "_contract": {
+    "tileset": "32 slots (8x4 grid at 16x16px). Indices 0-31 are fixed contract.",
+    "npcs": "9 NPC sprites with zone assignments. IDs must match world/packs/base/npcs/*.json",
+    "players": "3 player variants (human, agent, object)",
+    "validation": "Run 'pnpm verify:maps' to validate contract compliance"
+  },
 
   "sources": {
     "city": {


### PR DESCRIPTION
## Summary

**Fixes #233** - Kenney tileset manifest contract is now documented and verified.

## Current Contract Status

The manifest at `tools/kenney-curation.json` is confirmed as the **single source of truth** for:

| Asset Type | Count | Contract |
|------------|-------|----------|
| Tileset | 32 tiles | 8x4 grid at 16x16px, indices 0-31 |
| NPCs | 9 sprites | Zone assignments must match world/packs/base/npcs/*.json |
| Players | 3 variants | human, agent, object |

## Verification

All extraction scripts use the manifest:
- `extract_tileset.py` - reads tileset definitions from manifest
- `extract_npc_sprites.py` - reads NPC definitions from manifest
- `extract_player_sprites.py` - reads player definitions from manifest
- `verify-map-stack-consistency.mjs` - validates contract compliance

```bash
pnpm verify:maps           # ✅ Contract validation passes
python3 tools/extract_tileset.py  # ✅ 32 tiles extracted
python3 tools/extract_npc_sprites.py  # ✅ 9 NPCs extracted
python3 tools/extract_player_sprites.py  # ✅ 3 players extracted
```

## Changes

Added `_contract` field to manifest documenting the fixed contract for future reference.

## Checklist

- [x] 32-slot tileset contract explicitly defined
- [x] Extraction scripts use manifest only
- [x] Verification script validates contract
- [x] All extraction commands succeed
- [x] `pnpm verify:maps` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타**
  * 게임 에셋 구조 명세가 추가되었습니다. 타일셋(16x16px, 8x4 그리드), NPC 스프라이트(9종), 플레이어 캐릭터 변형(3종)에 대한 정의 및 검증 지침이 포함되어 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->