### PR TITLE
docs: complete #245/#248 checklist and unified command adoption

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,6 +37,7 @@
 
 #### Verification Commands
 
+- [ ] `pnpm verify:map-change` executed (recommended unified command)
 - [ ] `pnpm sync-maps` executed
 - [ ] `node scripts/verify-map-stack-consistency.mjs` passes
 - [ ] `pnpm build` succeeds
@@ -49,6 +50,7 @@
 - [ ] Spawn coordinates within valid bounds
 - [ ] Collision layer values are 0 or 1 only
 - [ ] NPC IDs match atlas frame keys
+- [ ] Minimap regression checked (zone/road/water + viewport alignment)
 - [ ] No hardcoded zone/coordinate values added
 
 #### Documentation

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ Map expansion or tile changes must follow the same issue-first routine to preven
 **Core verification commands:**
 
 ```bash
+pnpm verify:map-change                      # Unified map-change verification (recommended)
+# Expanded form (same pipeline):
 pnpm sync-maps                              # Sync source to server/client
 node scripts/verify-map-stack-consistency.mjs  # Validate consistency
 pnpm test                                   # Run tests

--- a/docs/reference/map-change-routine.md
+++ b/docs/reference/map-change-routine.md
@@ -30,6 +30,8 @@
    - 타일/NPC/플레이어 에셋은 `tools/kenney-curation.json` 계약을 우선 반영한다.
 
 3. 정합성 검증
+   - `pnpm verify:map-change` (권장 단일 명령)
+   - 필요 시 상세 확인:
    - `pnpm sync-maps`
    - `node scripts/verify-map-stack-consistency.mjs`
    - `pnpm test`


### PR DESCRIPTION
## What
Follow-up remediation for merged Wave1 PRs to fully satisfy issue acceptance criteria:
- #245: map-impact checklist completeness
- #248: single-command usage visibility in docs/templates

## Changes
- `.github/pull_request_template.md`
  - Added explicit `pnpm verify:map-change` unified command checkbox
  - Added minimap regression check item (zone/road/water + viewport alignment)
- `README.md`
  - Updated Map Consistency Workflow commands to show `pnpm verify:map-change` as recommended entry
- `docs/reference/map-change-routine.md`
  - Added unified command in mandatory verification step before expanded commands

## Why
Validation against issue DoD found two gaps:
1. #245 checklist did not explicitly include minimap regression verification.
2. #248 DoD expects docs/PR flow to use a single command; docs emphasized only expanded commands.

## Bot Feedback Analysis
- CodeRabbit/Gemini on PRs #260/#261 had no actionable technical comments (rate-limit or summary only).
- This follow-up addresses DoD-level completeness gaps found during explicit verification.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm build` ✅
- `pnpm test` ✅ (994 passed)
- `pnpm verify:maps` ✅

## Context
Sequential verification/remediation requested for merged PRs #259-#262.