### PR TITLE
docs: add CODEOWNERS enforcement setup guide (#247 follow-up)

### DIFF
--- a/docs/reference/codeowners-enforcement-setup.md
+++ b/docs/reference/codeowners-enforcement-setup.md
@@ -1,0 +1,31 @@
+# CODEOWNERS Enforcement Setup
+
+This project uses `.github/CODEOWNERS` for map-stack review routing.
+
+CODEOWNERS alone does not block merges. To enforce approvals, configure branch protection.
+
+## Required GitHub Setup
+
+1. Create teams used in `.github/CODEOWNERS`:
+   - `@Two-Weeks-Team/maintainers`
+   - `@Two-Weeks-Team/map-reviewers`
+   - `@Two-Weeks-Team/asset-reviewers`
+   - `@Two-Weeks-Team/server-reviewers`
+   - `@Two-Weeks-Team/client-reviewers`
+
+2. Open repository settings:
+   - `Settings -> Branches -> Branch protection rules`
+
+3. For the protected branch (`main`):
+   - Enable `Require a pull request before merging`
+   - Enable `Require approvals`
+   - Enable `Require review from Code Owners`
+
+4. Optional hardening:
+   - Enable `Dismiss stale pull request approvals when new commits are pushed`
+   - Enable `Require status checks to pass before merging`
+
+## Verification
+
+After setup, modify a path owned by CODEOWNERS (for example `world/packs/base/maps/`) and open a PR.
+GitHub should automatically request the mapped team reviewers and block merge until required approvals are satisfied.

--- a/docs/reference/map-change-routine.md
+++ b/docs/reference/map-change-routine.md
@@ -67,3 +67,4 @@
 1. `docs/task-issue-registry-2026-02-13.md`
 2. `docs/reference/map-sync-process.md`
 3. `docs/master-stabilization-plan-2026-02-13.md`
+4. `docs/reference/codeowners-enforcement-setup.md`


### PR DESCRIPTION
## What
Add explicit setup documentation to make CODEOWNERS review enforcement operational, not only declarative.

## Why
Issue #247 requires CODEOWNERS + protected-branch review enforcement behavior. The merged PR added `.github/CODEOWNERS`, but repository/org settings steps were not documented in-repo.

## Changes
- Added `docs/reference/codeowners-enforcement-setup.md`
  - required GitHub teams
  - branch protection configuration
  - verification steps
- Linked the setup doc from `docs/reference/map-change-routine.md`

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm build` ✅
- `pnpm test` ✅ (994 passed)
- `pnpm verify:maps` ✅

## Context
Sequential verification/remediation requested for merged PRs #259-#262.