### PR TITLE
fix(server): broadcast AIC chat messages to WebSocket clients (#282)

### DIFF
--- a/packages/server/src/aic/handlers/chatSend.ts
+++ b/packages/server/src/aic/handlers/chatSend.ts
@@ -130,6 +130,13 @@ export async function handleChatSend(req: Request, res: Response): Promise<void>
 
     const { messageId, tsMs } = result;
 
+    // Broadcast to WebSocket clients so human players see AI agent messages in real-time
+    gameRoom.broadcast('chat', {
+      from: agentEntity.name,
+      message,
+      entityId: agentId,
+    });
+
     const eventLog = gameRoom.getEventLog();
     eventLog.append('chat.message', roomId, {
       messageId,


### PR DESCRIPTION
## Summary
- Fix critical bug where AI agent chat messages via AIC API were invisible to human players
- Add `gameRoom.broadcast('chat', ...)` call in chatSend handler

## Problem
When AI agents send chat messages via `/aic/v0.1/chatSend`, human players connected via WebSocket do NOT see these messages in real-time. The handler stored messages and logged events, but never broadcast to WebSocket clients.

## Solution
Add broadcast call after successfully storing the message, matching the behavior of the WebSocket chat handler in `GameRoom.ts`.

```typescript
gameRoom.broadcast('chat', {
  from: agentEntity.name,
  message,
  entityId: agentId,
});
```

## Validation
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (997 tests)
- [x] Code follows existing patterns in GameRoom.ts

## Related
- Closes #282
- Part of chat system analysis findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * AI 에이전트 채팅 메시지의 실시간 브로드캐스트 기능이 추가되었습니다. 연결된 클라이언트들이 에이전트 이름, 메시지 내용과 함께 메시지를 실시간으로 수신할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->