### PR TITLE
fix(shared): add missing optional fields to ChatMessageSchema (#285)

### DIFF
--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -295,6 +295,10 @@ export const ChatMessageSchema = z.object({
   fromName: z.string().min(1).max(64),
   message: z.string().min(1).max(500),
   tsMs: TsMsSchema,
+  targetEntityId: IdEntitySchema.optional(),
+  teamId: z.string().min(1).max(64).optional(),
+  meetingRoomId: z.string().min(1).max(64).optional(),
+  emotes: z.array(z.string().min(1).max(32)).optional(),
 });
 
 export const ChatObserveResponseDataSchema = z.object({


### PR DESCRIPTION
## Summary
- Align ChatMessageSchema with ChatMessage TypeScript type
- Add 4 optional fields for extended chat features

## Problem
The `ChatMessage` type had optional fields not present in the Zod schema:
- `targetEntityId` - For DM messages
- `teamId` - For team chat  
- `meetingRoomId` - For meeting chat
- `emotes` - For parsed emotes like :thumbsup:

This caused validation to strip these fields when parsing chat messages.

## Changes
```typescript
export const ChatMessageSchema = z.object({
  // ... existing fields ...
  targetEntityId: IdEntitySchema.optional(),
  teamId: z.string().min(1).max(64).optional(),
  meetingRoomId: z.string().min(1).max(64).optional(),
  emotes: z.array(z.string().min(1).max(32)).optional(),
});
```

## Validation
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (997 tests)

## Related
- Closes #285
- Unblocks: Team chat, DM, meeting chat features