### PR TITLE
fix(server): address review feedback for chat system (#283, #289)

### DIFF
--- a/packages/server/src/aic/handlers/chatObserve.ts
+++ b/packages/server/src/aic/handlers/chatObserve.ts
@@ -72,7 +72,7 @@ export async function handleChatObserve(req: Request, res: Response): Promise<vo
       return;
     }
 
-    const messages = chatSystem.getMessages(roomId, channel, windowSec);
+    const messages = chatSystem.getMessagesForEntity(roomId, agentId, channel, windowSec);
 
     const responseData: ChatObserveResponseData = {
       messages,

--- a/packages/server/src/aic/handlers/chatSend.ts
+++ b/packages/server/src/aic/handlers/chatSend.ts
@@ -135,6 +135,9 @@ export async function handleChatSend(req: Request, res: Response): Promise<void>
       from: agentEntity.name,
       message,
       entityId: agentId,
+      channel,
+      messageId,
+      tsMs,
     });
 
     const eventLog = gameRoom.getEventLog();


### PR DESCRIPTION
## Summary
Address code review feedback from CodeRabbit and Gemini on recently merged chat system PRs.

## Changes

### 1. chatSend.ts - Broadcast payload enhancement (PR #283 feedback)
**CodeRabbit noted**: broadcast payload missing `channel`, `messageId`, `tsMs` fields

```diff
 gameRoom.broadcast('chat', {
   from: agentEntity.name,
   message,
   entityId: agentId,
+  channel,
+  messageId,
+  tsMs,
 });
```

### 2. chatObserve.ts - Access control fix (PR #289 feedback)
**Gemini noted**: Security flaw - `getMessages()` doesn't filter DM/team messages by recipient

```diff
- const messages = chatSystem.getMessages(roomId, channel, windowSec);
+ const messages = chatSystem.getMessagesForEntity(roomId, agentId, channel, windowSec);
```

`getMessagesForEntity` properly filters:
- DM messages (only sender/recipient can see)
- Blocked user messages (filtered by SafetyService)

## Validation
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (997 tests)

## Related
- Follow-up to PR #283 and PR #289