### PR TITLE
fix(#278): expand Map Consistency CI trigger patterns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,11 @@ jobs:
             'world/packs/base/assets/tilesets/**'
             'scripts/sync-maps.mjs'
             'scripts/verify-map-stack-consistency.mjs'
+            'world/packs/base/npcs/**'
+            'world/packs/base/facilities/**'
+            'world/packs/base/manifest.json'
+            'packages/server/src/world/**'
+            'packages/shared/src/world.ts'
           )
 
           CHANGED_FILES=$(git diff --name-only "$BASE_SHA"...HEAD 2>/dev/null || git diff --name-only HEAD~1...HEAD)
@@ -215,6 +220,7 @@ jobs:
           for pattern in "${MAP_PATTERNS[@]}"; do
             if echo "$CHANGED_FILES" | grep -q "^${pattern/\*\*/.*}"; then
               MAP_CHANGED=true
+              echo "📍 Matched pattern: $pattern"
               break
             fi
           done


### PR DESCRIPTION
## Summary

This PR expands the Map Consistency CI trigger patterns to include NPC, facility, manifest, and world package changes as requested in issue #278.

## Changes

### Added MAP_PATTERNS:
- world/packs/base/npcs/** - NPC definition files
- world/packs/base/facilities/** - Facility definition files  
- world/packs/base/manifest.json - World package manifest
- packages/server/src/world/** - Server world package code
- packages/shared/src/world.ts - Shared world types

### Added logging:
- Added echo \"📍 Matched pattern: \$pattern\" to show which pattern triggered the map-consistency job

## Verification

The following paths will now trigger the map-consistency CI job:
- world/packs/base/npcs/npc.json
- world/packs/base/manifest.json
- packages/server/src/world/WorldPackLoader.ts
- packages/shared/src/world.ts

## Checklist

- CI workflow syntax validated with pnpm lint
- New patterns added without removing existing ones
- Pattern match logging implemented
- Branch created from main

Closes #278