### PR TITLE
fix(server): implement auth token validation in skill handlers

### DIFF
--- a/packages/server/src/aic/handlers/skillInstall.ts
+++ b/packages/server/src/aic/handlers/skillInstall.ts
@@ -23,7 +23,13 @@ export async function handleSkillInstall(req: Request, res: Response): Promise<v
   const body = req.validatedBody as SkillInstallRequest;
   const { agentId, roomId, skillId, credentials } = body;
 
-  // TODO(security): Validate req.authToken maps to agentId (requires token registry)
+  if (req.authAgentId !== agentId) {
+    res
+      .status(403)
+      .json(createErrorResponse('forbidden', 'Agent ID mismatch with auth token', false));
+    return;
+  }
+
   try {
     const colyseusRoomId = getColyseusRoomId(roomId);
 

--- a/packages/server/src/aic/handlers/skillInvoke.ts
+++ b/packages/server/src/aic/handlers/skillInvoke.ts
@@ -26,7 +26,13 @@ export async function handleSkillInvoke(req: Request, res: Response): Promise<vo
   const body = req.validatedBody as SkillInvokeRequest;
   const { agentId, roomId, skillId, actionId, params } = body;
 
-  // TODO(security): Validate req.authToken maps to agentId (requires token registry)
+  if (req.authAgentId !== agentId) {
+    res
+      .status(403)
+      .json(createErrorResponse('forbidden', 'Agent ID mismatch with auth token', false));
+    return;
+  }
+
   const txId = (body as { txId?: string }).txId ?? `tx_${uuidv4()}`;
 
   try {

--- a/packages/server/src/aic/handlers/skillList.ts
+++ b/packages/server/src/aic/handlers/skillList.ts
@@ -23,7 +23,13 @@ export async function handleSkillList(req: Request, res: Response): Promise<void
   const body = req.validatedBody as SkillListRequest;
   const { agentId, roomId, category, installed } = body;
 
-  // TODO(security): Validate req.authToken maps to agentId (requires token registry)
+  if (req.authAgentId !== agentId) {
+    res
+      .status(403)
+      .json(createErrorResponse('forbidden', 'Agent ID mismatch with auth token', false));
+    return;
+  }
+
   try {
     const colyseusRoomId = getColyseusRoomId(roomId);
 


### PR DESCRIPTION
## Summary
- Add agentId validation against authAgentId from token in all 3 skill handlers
- Return 403 forbidden error when agentId doesn't match auth token
- Remove security TODO comments as validation is now implemented

## Changes
| File | Change |
|------|--------|
| `skillList.ts` | Added auth validation before processing |
| `skillInstall.ts` | Added auth validation before processing |
| `skillInvoke.ts` | Added auth validation before processing |

## Security
Prevents agents from impersonating other agents when:
- Listing skills (could see another agent's installed skills)
- Installing skills (could install skills for another agent)
- Invoking skills (could invoke skills on behalf of another agent)

Closes #288