### PR TITLE
fix: recover resident loop from unregister failure stalls

### DIFF
--- a/scripts/resident-agent-loop.ts
+++ b/scripts/resident-agent-loop.ts
@@ -1208,7 +1208,7 @@ class IssueDetector {
   detectStuckAgent(agents: ResidentAgent[]): Issue | null {
     for (const agent of agents) {
       const state = agent.getState();
-      const detectorKey = `stuckAgent:${state.agentId || `unregistered:${state.role}`}`;
+      const detectorKey = `stuckAgent:${state.agentId || `unregistered:${agent.getInstanceId()}`}`;
 
       if (state.role === 'afk' || !state.agentId || !state.sessionToken) {
         this.resetConsecutive(detectorKey);
@@ -1875,6 +1875,7 @@ class ResidentAgent {
   private serverUrl: string;
   private running = false;
   private cycleDelayMs: number;
+  private readonly instanceId = randomBytes(4).toString('hex');
 
   constructor(serverUrl: string, role: AgentRole, cycleDelayMs: number) {
     this.serverUrl = serverUrl;
@@ -1902,6 +1903,10 @@ class ResidentAgent {
 
   getState(): AgentState {
     return this.state;
+  }
+
+  getInstanceId(): string {
+    return this.instanceId;
   }
 
   async register(roomId: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
This PR fixes a resident-loop failure mode where agents can get stuck in a repeated failure cycle after `unregister` errors, then repeatedly trigger issue #307.

## What Changed
- Treat `unregister` HTTP `401/403/404` as recoverable lifecycle states.
- Clear local registration state (`agentId`, `sessionToken`, `eventCursor`) when recoverable `unregister` responses occur.
- Make `reregister()` resilient: if `unregister()` throws, continue via local state reset and retry registration path.
- Harden stuck detection reset logic so consecutive counters are cleared when an agent is not currently violating stuck conditions.

## Why
Issue #307 reports an agent with `last action: unregister` and sustained high failure rate. In the previous flow, `reregister()` could be blocked by `unregister()` failure and never progress to registration recovery.

## Acceptance Criteria Mapping
- [x] Agent should continue actions instead of remaining stuck after lifecycle API errors.
- [x] Recoverable `unregister` statuses do not trap the agent in a fail loop.
- [x] Stuck detector does not carry stale consecutive counts once conditions recover.

## Local CI / Validation
- `pnpm --filter @openclawworld/shared build`
- `pnpm generate:tools`
- `pnpm generate:commands`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test -- --coverage`

All commands passed locally.

## Risk / Rollback
- Risk: Recoverable classification for `unregister` may hide some lifecycle-side failures.
- Mitigation: Limited to `401/403/404` and still logs warning context.
- Rollback: Revert this PR commit to restore previous strict `unregister` behavior.

Closes #307
