### PR TITLE
fix(resident-loop): add starvation boost to prevent candidate starvation

### DIFF
--- a/scripts/resident-agent-loop.ts
+++ b/scripts/resident-agent-loop.ts
@@ -2192,8 +2192,9 @@ class ResidentAgent {
     }
 
     const isStarving = observedFacilities.size === 0 && observedEntities.size === 0;
+    const wanderLabel = isStarving ? 'navigate:wander:starvation' : 'navigate:wander';
     const baseWanderWeight =
-      this.getRolePreference('wander') * this.computeNoveltyMultiplier('navigate:wander');
+      this.getRolePreference('wander') * this.computeNoveltyMultiplier(wanderLabel);
     const wanderWeight = isStarving
       ? Math.max(baseWanderWeight * STARVATION_WANDER_BOOST, STARVATION_MIN_WANDER_WEIGHT)
       : baseWanderWeight;
@@ -2205,7 +2206,7 @@ class ResidentAgent {
     candidates.push({
       action: () => this.moveTo(tx, ty),
       weight: wanderWeight,
-      label: isStarving ? 'navigate:wander:starvation' : 'navigate:wander',
+      label: wanderLabel,
       category: 'navigate',
     });
 


### PR DESCRIPTION
## Summary
- Add starvation boost (10x multiplier, min weight 0.5) when agent observes no facilities/entities
- Use center-biased wander targets during starvation to increase probability of finding populated areas
- Add `navigate:wander:starvation` label for debugging/metrics

## Root Cause Analysis

When agents spawned or wandered into empty areas (no facilities/entities within observe radius), they would get stuck because:

1. `observedFacilities.size === 0 && observedEntities.size === 0` meant no facility/entity-based candidates
2. Wander weight was too low (0.01-0.3 depending on role) relative to observe/chat weights
3. Agents kept selecting non-movement actions (observe, chat, pollEvents) that don't change position
4. Without movement, observe results stayed empty → feedback loop

## Solution

**Starvation Boost**: When both `observedFacilities` and `observedEntities` are empty:
- Multiply wander weight by 10x
- Enforce minimum weight of 0.5 to guarantee competitive selection probability
- Use center-biased random targets (facilities tend to cluster centrally)

## Testing

- [x] `pnpm typecheck` - passes
- [x] `pnpm test` - 1016 tests pass

Closes #309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 레지던트 에이전트에 배고픔 인식 배회 동작 추가: 주변에 시설이나 개체가 없을 때 더 높은 우선도로 지도 중심 쪽으로 배회하도록 하여 행동이 더 목적지향적이고 현실감 있게 개선됩니다.
  * 배회 행동은 상황에 따라 동적 가중치와 레이블로 구분되어 일반 배회와 배고픔 시 배회를 구분합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->