### PR TITLE
fix(resident-loop): auto-reregister on 401/403 authentication errors

### DIFF
--- a/scripts/resident-agent-loop.ts
+++ b/scripts/resident-agent-loop.ts
@@ -2321,11 +2321,11 @@ class ResidentAgent {
 
         if (this.isAuthError(error)) {
           this.state.consecutiveAuthErrors++;
-          console.warn(
-            `[${this.state.agentId}] Auth error detected (${this.state.consecutiveAuthErrors}/${MAX_CONSECUTIVE_AUTH_ERRORS}), attempting re-registration...`
-          );
 
           if (this.state.consecutiveAuthErrors <= MAX_CONSECUTIVE_AUTH_ERRORS) {
+            console.warn(
+              `[${this.state.agentId}] Auth error detected (${this.state.consecutiveAuthErrors}/${MAX_CONSECUTIVE_AUTH_ERRORS}), attempting re-registration...`
+            );
             try {
               await this.reregister('default');
               console.log(`[${this.state.agentId}] Re-registration successful after auth error`);
@@ -2355,7 +2355,7 @@ class ResidentAgent {
     if (!(error instanceof Error)) return false;
 
     const message = error.message;
-    // Pattern: "Observe failed: 401", "Move failed: 403"
+    // Pattern: "Observe failed: 401", "Move failed: 401"
     const statusMatch = message.match(/failed:\s*(\d{3})/i);
     if (statusMatch) {
       const statusCode = parseInt(statusMatch[1], 10);


### PR DESCRIPTION
## Summary

Fixes the root cause of high error rates (81%) reported in Issue #324. When agents receive HTTP 401/403 errors, they now automatically re-register instead of continuing with invalid tokens.

## Root Cause Analysis

From Issue #324's sample error messages:
```
[chatSend] client_error: Chat failed: 401 (HTTP 401)
[moveTo] client_error: Move failed: 401 (HTTP 401)
[observe] client_error: Observe failed: 401 (HTTP 401)
```

All failures were **authentication errors**. The agent's `start()` method was simply logging these errors and continuing, never attempting to re-register.

## Solution

1. **Add `isAuthError()` helper** - Detects 401/403 from error messages using regex pattern matching
2. **Track `consecutiveAuthErrors`** - Prevents infinite reregistration loops (max 3 attempts)
3. **Auto-reregister on auth errors** - Calls `reregister()` when authentication fails
4. **Exponential backoff** - Adds delay on failed reregistration attempts

## Changes

| File | Change |
|------|--------|
| `scripts/resident-agent-loop.ts` | Add auth error detection and auto-reregistration logic |

## Testing

- [x] `pnpm typecheck` - All packages pass
- [x] `pnpm test` - 1016 tests pass

## Behavior After Fix

1. Agent receives 401 on API call
2. `isAuthError()` detects authentication failure
3. Agent logs warning and calls `reregister()`
4. On success: continues with new token
5. On failure: exponential backoff, retry up to 3 times
6. After 3 failures: stops retrying, logs error

Closes #324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 오류 자동 감지 및 처리 추가
  * 인증 실패 발생 시 재등록(재시도) 흐름 적용
  * 재시도에 지수 백오프 전략 적용 및 최대 시도 횟수 제한 도입
  * 연속 인증 실패 횟수 추적으로 과도한 재시도 방지
  * 정상 동작 시 인증 실패 카운터 초기화 처리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->