### PR TITLE
fix(config): align .env.test ALLOWED_ORIGINS with .env.example (#346)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 NODE_ENV=development
 PORT=2567
-ALLOWED_ORIGINS=*
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
 
 LOG_LEVEL=debug


### PR DESCRIPTION
## Summary

Aligns CORS configuration between test and development environments to ensure consistent behavior.

### Change

| File | Before | After |
|------|--------|-------|
| `.env.test` | `ALLOWED_ORIGINS=*` | `ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000` |

### Rationale

- Tests should run under same CORS restrictions as development
- Prevents tests from passing while actual dev environment has CORS issues
- Maintains parity between `.env.example` and `.env.test`

### Verification

- ✅ All 1042 tests still pass with the new configuration

Closes #346