### PR TITLE
fix(#414): invalidate agent token on stale agent cleanup

### DIFF
--- a/packages/server/src/rooms/GameRoom.ts
+++ b/packages/server/src/rooms/GameRoom.ts
@@ -778,7 +778,9 @@ export class GameRoom extends Room<{ state: RoomState }> {
       this.state.removeEntity(id, 'agent');
       const tokenInvalidated = invalidateAgentToken(id);
       if (!tokenInvalidated) {
-        console.warn(`[GameRoom] stale agent ${id} (${name}) had no token registered in tokenRegistry`);
+        console.warn(
+          `[GameRoom] stale agent ${id} (${name}) had no token registered in tokenRegistry`
+        );
       }
 
       this.eventLog.append('presence.leave', this.state.roomId, {


### PR DESCRIPTION
## Summary
- `cleanupStaleAgents()` now calls `invalidateAgentToken()` when removing inactive agents
- Prevents removed agents from retaining valid session tokens indefinitely
- Fixes token registry memory leak where entries accumulated for cleaned-up agents

## Changes
- `GameRoom.ts`: Added import for `invalidateAgentToken` and call in `cleanupStaleAgents()`

## Test plan
- [ ] Build passes (`pnpm build`)
- [ ] After agent times out, its token returns "invalid" on next API call
- [ ] Token registry size does not grow unboundedly over time

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 방 종료 시 남아 있는 에이전트의 인증 토큰을 명시적으로 무효화하여 세션 정리 강화
  * 유휴(스테일) 에이전트 정리 시 해당 에이전트의 토큰도 무효화하도록 개선
  * 에이전트 퇴장 처리 시 토큰 무효화 실패 상황을 로깅해 문제 추적성을 향상시키고 운영 안정성 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->