### PR TITLE
fix(#394): register GameRoom in roomRegistry on create/dispose

### DIFF
--- a/packages/server/src/rooms/GameRoom.ts
+++ b/packages/server/src/rooms/GameRoom.ts
@@ -41,6 +41,7 @@ import { DEFAULT_SPAWN_POINT } from '@openclawworld/shared';
 import { getMetricsCollector } from '../metrics/MetricsCollector.js';
 import { WorldPackLoader, WorldPackError, type WorldPack } from '../world/WorldPackLoader.js';
 import { SkillService } from '../services/SkillService.js';
+import { registerRoom, unregisterRoom } from '../aic/roomRegistry.js';
 
 const DEFAULT_NPC_SEED = 12345;
 const __filename = fileURLToPath(import.meta.url);
@@ -140,6 +141,7 @@ export class GameRoom extends Room<{ state: RoomState }> {
 
     this.setState(new RoomState(roomId, mapId, tickRate, gameMap));
     this.setMetadata({ roomId });
+    registerRoom(roomId, this.roomId);
     this.facilityService = new FacilityService(this.state);
     registerAllFacilityHandlers(this.facilityService);
     this.loadFacilitiesFromWorldPack();
@@ -724,6 +726,7 @@ export class GameRoom extends Room<{ state: RoomState }> {
 
   override onDispose(): void {
     console.log(`[GameRoom] Disposing room ${this.state.roomId}`);
+    unregisterRoom(this.state.roomId);
     this.clientEntities.clear();
     this.recentProximityEvents = [];
 


### PR DESCRIPTION
## Summary
- GameRoom now registers itself in `roomRegistry` during `onCreate()` and unregisters during `onDispose()`
- Fixes the issue where humans and agents were placed in separate room instances because agent `/register` couldn't find the human-created room

## Changes
- `GameRoom.ts`: Added import for `registerRoom`/`unregisterRoom` from roomRegistry
- `onCreate()`: Added `registerRoom(roomId, this.roomId)` after `setMetadata()`
- `onDispose()`: Added `unregisterRoom(this.state.roomId)` at start

## Test plan
- [ ] Build passes (`pnpm build`)
- [ ] Human connects via WebSocket → agent registers via REST → both in same room
- [ ] `/observe` returns both human and agent entities
- [ ] Room disposal properly cleans up registry entry

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)