### PR TITLE
feat(#398): add filterBy metadata.roomId to game room definition

### DIFF
--- a/packages/server/src/app.config.ts
+++ b/packages/server/src/app.config.ts
@@ -36,7 +36,7 @@ function getCorsOrigin(): string[] | false {
 
 const server = defineServer({
   rooms: {
-    game: defineRoom(GameRoom),
+    game: defineRoom(GameRoom).filterBy(['metadata.roomId']),
     meeting: defineRoom(MeetingRoom),
   },
 


### PR DESCRIPTION
## Summary
Resolves #398

Adds `filterBy(['metadata.roomId'])` to the game room definition in `app.config.ts` so that Colyseus routes join/create requests to the correct room instance based on the `roomId` metadata field.

## Changes
- Added `.filterBy(['metadata.roomId'])` to `defineRoom(GameRoom)` in `app.config.ts`

## Testing
- [x] Build passes (`pnpm build`)
- [x] Existing room creation and joining still works via metadata routing

## Checklist
- [x] Code follows project conventions
- [x] No breaking changes