### PR TITLE
fix(#412): defer entity cleanup until after reconnection window

### DIFF
--- a/packages/server/src/rooms/GameRoom.ts
+++ b/packages/server/src/rooms/GameRoom.ts
@@ -691,6 +691,16 @@ export class GameRoom extends Room<{ state: RoomState }> {
     const entityId = this.clientEntities.get(client.sessionId);
     const consented = code === undefined;
 
+    if (!consented && entityId) {
+      try {
+        await this.allowReconnection(client, 20);
+        console.log(`[GameRoom] Client ${client.sessionId} reconnected`);
+        return;
+      } catch {
+        console.log(`[GameRoom] Client ${client.sessionId} did not reconnect in time`);
+      }
+    }
+
     if (entityId) {
       if (this.zoneSystem) {
         this.zoneSystem.removeEntity(entityId, this.eventLog, this.state.roomId);
@@ -710,15 +720,6 @@ export class GameRoom extends Room<{ state: RoomState }> {
       });
 
       console.log(`[GameRoom] Client ${client.sessionId} left, removed ${entityId}`);
-    }
-
-    if (!consented) {
-      try {
-        await this.allowReconnection(client, 20);
-        console.log(`[GameRoom] Client ${client.sessionId} reconnected`);
-      } catch {
-        console.log(`[GameRoom] Client ${client.sessionId} did not reconnect in time`);
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
Resolves #412

Fixes the reconnection flow in `GameRoom.onLeave()` where entity state was deleted **before** the reconnection window opened, making reconnect meaningless.

## Changes
- Reordered `onLeave()` to attempt `allowReconnection()` first for non-consented disconnects
- Entity cleanup (zone removal, skill cleanup, state removal, event logging) now only happens after reconnection fails or on consented leave
- On successful reconnect, the method returns early preserving the player entity

## Testing
- [x] Build passes (`pnpm build`)
- [x] Consented leave still cleans up immediately
- [x] Non-consented disconnect waits for reconnection before cleanup

## Checklist
- [x] Code follows project conventions
- [x] No breaking changes