### PR TITLE
fix(#420): replace Math.random with crypto.randomUUID for ID generation

### DIFF
--- a/packages/server/src/rooms/GameRoom.ts
+++ b/packages/server/src/rooms/GameRoom.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { Room, type Client } from 'colyseus';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -220,7 +221,7 @@ export class GameRoom extends Room<{ state: RoomState }> {
         const entity = this.state.getEntity(entityId);
         if (!entity) return;
 
-        const txId = `ws_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        const txId = `ws_${randomUUID()}`;
         void this.skillService
           .invokeAction(
             entityId,
@@ -274,7 +275,7 @@ export class GameRoom extends Room<{ state: RoomState }> {
         const entity = this.state.getEntity(entityId);
         if (!entity) return;
 
-        const txId = `ws_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        const txId = `ws_${randomUUID()}`;
         const outcome = this.handleInteraction(
           entityId,
           data.targetId,

--- a/packages/server/src/schemas/AgendaSchema.ts
+++ b/packages/server/src/schemas/AgendaSchema.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { Schema, type, MapSchema } from '@colyseus/schema';
 
 export interface AgendaItemData {
@@ -188,7 +189,7 @@ export class AgendaSchema extends Schema {
   }
 
   private generateId(): string {
-    return `agenda_item_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+    return `agenda_item_${randomUUID()}`;
   }
 
   private reorderAllItems(): void {

--- a/packages/server/src/schemas/VoteSchema.ts
+++ b/packages/server/src/schemas/VoteSchema.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { Schema, MapSchema, type } from '@colyseus/schema';
 
 export interface VoteOptionData {
@@ -178,7 +179,7 @@ export class VoteSchema extends Schema {
   }
 
   private generateOptionId(): string {
-    return `option_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+    return `option_${randomUUID()}`;
   }
 
   private reorderOptions(): void {

--- a/packages/server/src/schemas/WhiteboardSchema.ts
+++ b/packages/server/src/schemas/WhiteboardSchema.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { Schema, MapSchema, type } from '@colyseus/schema';
 
 export type StickyNoteColor = 'yellow' | 'pink' | 'blue' | 'green';
@@ -99,6 +100,6 @@ export class WhiteboardSchema extends Schema {
   }
 
   private generateNoteId(): string {
-    return `note_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+    return `note_${randomUUID()}`;
   }
 }

--- a/packages/server/src/services/SafetyService.ts
+++ b/packages/server/src/services/SafetyService.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import type { SafetyReport, MutedUser } from '@openclawworld/shared';
 import type { AuditLog } from '../audit/AuditLog.js';
 
@@ -35,7 +36,7 @@ export class SafetyService {
    */
   reportUser(reporterId: string, targetId: string, reason: string, roomId?: string): SafetyReport {
     const report: SafetyReport = {
-      id: `report_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      id: `report_${randomUUID()}`,
       reporterId,
       targetId,
       reason,

--- a/packages/server/src/services/VotingService.ts
+++ b/packages/server/src/services/VotingService.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { VoteSchema, VoteCastSchema } from '../schemas/VoteSchema.js';
 
 export class VotingService {
@@ -73,7 +74,7 @@ export class VotingService {
       return null;
     }
 
-    const castId = `cast_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+    const castId = `cast_${randomUUID()}`;
     const cast = new VoteCastSchema({
       id: castId,
       optionId,


### PR DESCRIPTION
## Summary
Resolves #420

Replaces all `Date.now() + Math.random()` ID generation patterns with `crypto.randomUUID()` to eliminate collision risk under high concurrency and improve cryptographic safety.

## Changes
- **GameRoom.ts**: Transaction IDs (`ws_*`) now use `randomUUID()`
- **VotingService.ts**: Cast IDs (`cast_*`) now use `randomUUID()`
- **VoteSchema.ts**: Option IDs (`option_*`) now use `randomUUID()`
- **WhiteboardSchema.ts**: Note IDs (`note_*`) now use `randomUUID()`
- **AgendaSchema.ts**: Agenda item IDs (`agenda_item_*`) now use `randomUUID()`
- **SafetyService.ts**: Report IDs (`report_*`) now use `randomUUID()`

Note: `Math.random()` for dialogue array indexing (non-ID usage) is intentionally kept.

## Testing
- [x] Build passes (`pnpm build`)
- [x] Consistent with existing `randomUUID` usage in KanbanService, NoticeService, AuditLog

## Checklist
- [x] Code follows project conventions
- [x] No breaking changes (ID format change is internal only)