### PR TITLE
feat(#371): add explicit heartbeat endpoint for agents

### DIFF
--- a/packages/server/src/aic/handlers/heartbeat.ts
+++ b/packages/server/src/aic/handlers/heartbeat.ts
@@ -1,0 +1,12 @@
+import type { Request, Response } from 'express';
+import { AGENT_TIMEOUT_MS } from '../../constants.js';
+
+export function handleHeartbeat(req: Request, res: Response): void {
+  res.json({
+    ok: true,
+    agentId: req.authAgentId,
+    serverTsMs: Date.now(),
+    timeoutMs: AGENT_TIMEOUT_MS,
+    recommendedIntervalMs: Math.floor(AGENT_TIMEOUT_MS / 6),
+  });
+}

--- a/packages/server/src/aic/router.ts
+++ b/packages/server/src/aic/router.ts
@@ -39,6 +39,7 @@ import { handleProfileUpdate } from './handlers/profileUpdate.js';
 import { handleSkillList } from './handlers/skillList.js';
 import { handleSkillInstall } from './handlers/skillInstall.js';
 import { handleSkillInvoke } from './handlers/skillInvoke.js';
+import { handleHeartbeat } from './handlers/heartbeat.js';
 
 const router: Router = Router();
 
@@ -53,6 +54,8 @@ router.post(
 // All routes below require authentication
 router.use(authMiddleware);
 router.use(activityTrackerMiddleware);
+
+router.post('/heartbeat', handleHeartbeat);
 
 router.post(
   '/unregister',


### PR DESCRIPTION
## Summary
Resolves #371

Adds an explicit `POST /aic/v0.1/heartbeat` endpoint for agents to maintain presence. The endpoint sits behind `authMiddleware` and `activityTrackerMiddleware`, so calling it automatically refreshes the agent's activity timestamp.

## Changes
- **New handler**: `packages/server/src/aic/handlers/heartbeat.ts` - returns `ok`, `agentId`, `serverTsMs`, `timeoutMs`, and `recommendedIntervalMs`
- **Router update**: Added `/heartbeat` route after auth middleware

## Response Format
```json
{
  "ok": true,
  "agentId": "agent_xxx",
  "serverTsMs": 1708300000000,
  "timeoutMs": 300000,
  "recommendedIntervalMs": 50000
}
```

The `recommendedIntervalMs` is `AGENT_TIMEOUT_MS / 6` (~50s for default 5min timeout), giving agents clear guidance on heartbeat frequency.

## Testing
- [x] Build passes (`pnpm build`)
- [x] Endpoint is authenticated (behind authMiddleware)
- [x] Activity tracking automatic via activityTrackerMiddleware

## Checklist
- [x] Code follows project conventions
- [x] No breaking changes