### PR TITLE
fix(#364): preserve DialogueTree objects in NPC definition parsing

### DIFF
--- a/packages/server/src/world/WorldPackLoader.ts
+++ b/packages/server/src/world/WorldPackLoader.ts
@@ -1216,7 +1216,11 @@ export class WorldPackLoader {
         x: position.x ?? 0,
         y: position.y ?? 0,
       },
-      dialogue: Array.isArray(raw.dialogue) ? raw.dialogue : [],
+      dialogue: Array.isArray(raw.dialogue)
+        ? raw.dialogue
+        : raw.dialogue && typeof raw.dialogue === 'object'
+          ? (raw.dialogue as NpcDefinition['dialogue'])
+          : undefined,
       schedule: Array.isArray(raw.schedule)
         ? raw.schedule.map(s => {
             const item = s as {


### PR DESCRIPTION
## Summary
Resolves #364

NPCs with tree-structured dialogue (like River the Ranger) returned `"undefined"` when talked to.

## Root Cause
`WorldPackLoader.parseNpcDefinition()` only checked `Array.isArray(raw.dialogue)`, converting DialogueTree objects (which are plain objects, not arrays) to empty arrays `[]`. When `handleNpcTalk` then tried `dialogue[randomIndex]` on an empty array, it returned `undefined`.

## Changes
- **WorldPackLoader.ts**: `parseNpcDefinition` now correctly handles three dialogue formats:
  - `string[]` (simple random dialogue lines)
  - `DialogueTree` (tree-structured dialogue with nodes and options)
  - `undefined` (no dialogue configured)

## Testing
- [x] Build passes (`pnpm build`)
- [x] Ranger's dialogue tree is preserved as-is
- [x] Simple array dialogues still work
- [x] NPCs without dialogue still get default "Hello there!" fallback

## Checklist
- [x] Code follows project conventions
- [x] No breaking changes