### PR TITLE
feat(#397): add getOccupancy() and onJoin capacity check

### DIFF
--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -73,3 +73,14 @@ export const AGENT_TIMEOUT_MS = parseEnvInt(process.env.AGENT_TIMEOUT_MS, 300000
  * Override with AGENT_CLEANUP_INTERVAL_MS environment variable.
  */
 export const AGENT_CLEANUP_INTERVAL_MS = parseEnvInt(process.env.AGENT_CLEANUP_INTERVAL_MS, 60000);
+
+/**
+ * Maximum occupancy per channel room.
+ * Override with MAX_CHANNEL_OCCUPANCY environment variable.
+ */
+export const MAX_CHANNEL_OCCUPANCY = parseEnvInt(process.env.MAX_CHANNEL_OCCUPANCY, 30);
+
+/**
+ * Prefix for auto-generated channel room IDs.
+ */
+export const CHANNEL_PREFIX = 'channel';

--- a/packages/server/src/rooms/GameRoom.ts
+++ b/packages/server/src/rooms/GameRoom.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_MOVE_SPEED,
   AGENT_TIMEOUT_MS,
   AGENT_CLEANUP_INTERVAL_MS,
+  MAX_CHANNEL_OCCUPANCY,
 } from '../constants.js';
 import { EventLog } from '../events/EventLog.js';
 import { MovementSystem } from '../movement/MovementSystem.js';
@@ -319,6 +320,10 @@ export class GameRoom extends Room<{ state: RoomState }> {
 
   getNPCSystem(): NPCSystem | null {
     return this.npcSystem;
+  }
+
+  getOccupancy(): number {
+    return this.state.humans.size + this.state.agents.size;
   }
 
   getChatSystem(): ChatSystem | null {
@@ -664,6 +669,10 @@ export class GameRoom extends Room<{ state: RoomState }> {
   }
 
   override onJoin(client: Client, options: { name?: string }): void {
+    if (this.getOccupancy() >= MAX_CHANNEL_OCCUPANCY) {
+      throw new Error('Channel is full');
+    }
+
     const name = options.name ?? `Player ${client.sessionId.slice(0, 6)}`;
     const entityId = this.generateEntityId('human');
 


### PR DESCRIPTION
## Summary
Resolves #397, Closes #395

Adds channel occupancy tracking and capacity enforcement to GameRoom.

## Changes
- **GameRoom.ts**: Added `getOccupancy()` method (humans + agents count) and capacity check in `onJoin()` that throws when `MAX_CHANNEL_OCCUPANCY` is reached
- **constants.ts**: Added `MAX_CHANNEL_OCCUPANCY` (default 30, env configurable) and `CHANNEL_PREFIX` constants

## Testing
- [x] Build passes (`pnpm build`)
- [x] Colyseus propagates onJoin throw as client error

## Checklist
- [x] Code follows project conventions
- [x] No breaking changes