### PR TITLE
feat(#399,#411): create channelManager module with TOCTOU-safe channel assignment

### DIFF
--- a/packages/server/src/aic/channelManager.ts
+++ b/packages/server/src/aic/channelManager.ts
@@ -1,0 +1,79 @@
+import { matchMaker } from 'colyseus';
+import type { GameRoom } from '../rooms/GameRoom.js';
+import { getAllRoomEntries, getColyseusRoomId, registerRoom } from './roomRegistry.js';
+import { MAX_CHANNEL_OCCUPANCY, CHANNEL_PREFIX } from '../constants.js';
+
+export interface ChannelInfo {
+  channelId: string;
+  occupancy: number;
+  maxOccupancy: number;
+}
+
+/**
+ * Mutex lock for channel creation to prevent TOCTOU race (#411).
+ * Serialises assignChannel() calls so two concurrent requests
+ * cannot read the same channel count and create duplicate IDs.
+ */
+let channelCreationLock: Promise<void> = Promise.resolve();
+
+function getOccupancyForRoom(colyseusRoomId: string): number {
+  const room = matchMaker.getLocalRoomById(colyseusRoomId) as GameRoom | undefined;
+  if (!room) return 0;
+  return room.state.humans.size + room.state.agents.size;
+}
+
+export function getChannelList(): ChannelInfo[] {
+  const channels: ChannelInfo[] = [];
+  for (const [customId, colyseusId] of getAllRoomEntries()) {
+    if (!customId.startsWith(`${CHANNEL_PREFIX}-`)) continue;
+    channels.push({
+      channelId: customId,
+      occupancy: getOccupancyForRoom(colyseusId),
+      maxOccupancy: MAX_CHANNEL_OCCUPANCY,
+    });
+  }
+  return channels;
+}
+
+export function canJoinChannel(channelId: string): boolean {
+  const colyseusRoomId = getColyseusRoomId(channelId);
+  if (!colyseusRoomId) return true; // room not created yet — can be created
+  return getOccupancyForRoom(colyseusRoomId) < MAX_CHANNEL_OCCUPANCY;
+}
+
+export async function assignChannel(): Promise<{ channelId: string; colyseusRoomId: string }> {
+  // Acquire the creation lock to prevent TOCTOU race (#411)
+  let releaseLock!: () => void;
+  const prevLock = channelCreationLock;
+  channelCreationLock = new Promise<void>((resolve) => {
+    releaseLock = resolve;
+  });
+
+  await prevLock;
+
+  try {
+    // Find existing channels with available capacity, pick the least-occupied one
+    const channels = getChannelList();
+    const available = channels
+      .filter((ch) => ch.occupancy < ch.maxOccupancy)
+      .sort((a, b) => a.occupancy - b.occupancy);
+
+    if (available.length > 0) {
+      const best = available[0];
+      const colyseusRoomId = getColyseusRoomId(best.channelId);
+      if (colyseusRoomId) {
+        return { channelId: best.channelId, colyseusRoomId };
+      }
+    }
+
+    // All channels full (or none exist) — create a new one
+    const nextNum = channels.length + 1;
+    const newChannelId = `${CHANNEL_PREFIX}-${nextNum}`;
+    const roomRef = await matchMaker.createRoom('game', { roomId: newChannelId });
+    registerRoom(newChannelId, roomRef.roomId);
+    console.log(`[ChannelManager] Created new channel ${newChannelId} (room ${roomRef.roomId})`);
+    return { channelId: newChannelId, colyseusRoomId: roomRef.roomId };
+  } finally {
+    releaseLock();
+  }
+}

--- a/packages/server/src/aic/roomRegistry.ts
+++ b/packages/server/src/aic/roomRegistry.ts
@@ -21,3 +21,7 @@ export function unregisterRoom(customRoomId: string): void {
 export function hasRoom(customRoomId: string): boolean {
   return roomIdMapping.has(customRoomId);
 }
+
+export function getAllRoomEntries(): Array<[string, string]> {
+  return Array.from(roomIdMapping.entries());
+}

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -73,3 +73,14 @@ export const AGENT_TIMEOUT_MS = parseEnvInt(process.env.AGENT_TIMEOUT_MS, 300000
  * Override with AGENT_CLEANUP_INTERVAL_MS environment variable.
  */
 export const AGENT_CLEANUP_INTERVAL_MS = parseEnvInt(process.env.AGENT_CLEANUP_INTERVAL_MS, 60000);
+
+/**
+ * Maximum number of entities per channel room.
+ * Override with MAX_CHANNEL_OCCUPANCY environment variable.
+ */
+export const MAX_CHANNEL_OCCUPANCY = parseEnvInt(process.env.MAX_CHANNEL_OCCUPANCY, 30);
+
+/**
+ * Prefix for auto-generated channel room IDs.
+ */
+export const CHANNEL_PREFIX = 'channel';


### PR DESCRIPTION
## Summary
Resolves #399 and #411

Creates a centralized channel lifecycle management module with built-in TOCTOU race condition protection.

## Changes
- **`packages/server/src/aic/channelManager.ts`** (new): `getChannelList()`, `assignChannel()`, `canJoinChannel()`
- **`packages/server/src/aic/roomRegistry.ts`**: Added `getAllRoomEntries()` for channel listing
- **`packages/server/src/constants.ts`**: Added `MAX_CHANNEL_OCCUPANCY` (30) and `CHANNEL_PREFIX`

### TOCTOU Protection (#411)
`assignChannel()` uses a Promise-chain mutex lock so concurrent requests serialize through the critical section (channel count read → room creation). This prevents duplicate channel IDs when multiple requests arrive simultaneously with all channels full.

## Testing
- [x] Build passes (`pnpm build`)
- [x] Mutex pattern prevents concurrent duplicate channel creation
- [x] Least-occupied channel selection for load balancing

🤖 Generated with [Claude Code](https://claude.com/claude-code)