### PR TITLE
fix(#394): register GameRoom in roomRegistry on create/dispose

### DIFF
--- a/packages/server/src/rooms/GameRoom.ts
+++ b/packages/server/src/rooms/GameRoom.ts
@@ -41,6 +41,7 @@ import { DEFAULT_SPAWN_POINT } from '@openclawworld/shared';
 import { getMetricsCollector } from '../metrics/MetricsCollector.js';
 import { WorldPackLoader, WorldPackError, type WorldPack } from '../world/WorldPackLoader.js';
 import { SkillService } from '../services/SkillService.js';
+import { registerRoom, unregisterRoom } from '../aic/roomRegistry.js';
 
 const DEFAULT_NPC_SEED = 12345;
 const __filename = fileURLToPath(import.meta.url);
@@ -140,6 +141,7 @@ export class GameRoom extends Room<{ state: RoomState }> {
 
     this.setState(new RoomState(roomId, mapId, tickRate, gameMap));
     this.setMetadata({ roomId });
+    registerRoom(roomId, this.roomId);
     this.facilityService = new FacilityService(this.state);
     registerAllFacilityHandlers(this.facilityService);
     this.loadFacilitiesFromWorldPack();
@@ -724,6 +726,7 @@ export class GameRoom extends Room<{ state: RoomState }> {
 
   override onDispose(): void {
     console.log(`[GameRoom] Disposing room ${this.state.roomId}`);
+    unregisterRoom(this.state.roomId);
     this.clientEntities.clear();
     this.recentProximityEvents = [];
 


### PR DESCRIPTION
## Summary
Resolves #394

Fixes humans and agents being placed in different GameRoom instances because GameRoom didn't register itself in the roomRegistry.

## Root Cause
- `GameRoom.onCreate()` never called `registerRoom()`, so when agents registered via `/register`, `getColyseusRoomId()` returned `undefined` and a new room was created
- Humans and agents ended up in separate rooms, invisible to each other

## Changes
- **`packages/server/src/rooms/GameRoom.ts`**:
  - `onCreate()`: calls `registerRoom(roomId, this.roomId)` after `setMetadata()`
  - `onDispose()`: calls `unregisterRoom()` to clean up stale mappings

## Testing
- [x] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)