### PR TITLE
fix(#414): invalidate session tokens on stale agent cleanup

### DIFF
--- a/packages/server/src/rooms/GameRoom.ts
+++ b/packages/server/src/rooms/GameRoom.ts
@@ -41,6 +41,7 @@ import { DEFAULT_SPAWN_POINT } from '@openclawworld/shared';
 import { getMetricsCollector } from '../metrics/MetricsCollector.js';
 import { WorldPackLoader, WorldPackError, type WorldPack } from '../world/WorldPackLoader.js';
 import { SkillService } from '../services/SkillService.js';
+import { invalidateAgentToken } from '../aic/tokenRegistry.js';
 
 const DEFAULT_NPC_SEED = 12345;
 const __filename = fileURLToPath(import.meta.url);
@@ -757,6 +758,7 @@ export class GameRoom extends Room<{ state: RoomState }> {
       }
 
       this.state.removeEntity(id, 'agent');
+      invalidateAgentToken(id);
 
       this.eventLog.append('presence.leave', this.state.roomId, {
         entityId: id,


### PR DESCRIPTION
## Summary
Resolves #414

Stale agents removed by the cleanup timer had their entities deleted from room state but their session tokens remained valid in the token registry forever. This is a security vulnerability and memory leak.

## Changes
- **`packages/server/src/rooms/GameRoom.ts`**: Added `invalidateAgentToken(id)` call in `cleanupStaleAgents()` after `removeEntity()`

## Testing
- [x] Build passes (`pnpm build`)
- [x] Consistent with `unregister.ts` which already calls `invalidateAgentToken()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)