### PR TITLE
fix(#409): add filterBy roomId to GameRoom definition

### DIFF
--- a/packages/server/src/app.config.ts
+++ b/packages/server/src/app.config.ts
@@ -36,7 +36,7 @@ function getCorsOrigin(): string[] | false {
 
 const server = defineServer({
   rooms: {
-    game: defineRoom(GameRoom),
+    game: defineRoom(GameRoom).filterBy(['roomId']),
     meeting: defineRoom(MeetingRoom),
   },
 


### PR DESCRIPTION
## Summary
Resolves #409

Adds `filterBy(['roomId'])` to the GameRoom definition so Colyseus correctly matches clients to rooms based on their roomId option.

## Changes
- **`packages/server/src/app.config.ts`**: Added `.filterBy(['roomId'])` to game room definition

## Notes
- Uses `'roomId'` (not `'metadata.roomId'`) — Colyseus filterBy matches client option keys against room metadata keys automatically
- GameRoom already calls `this.setMetadata({ roomId })` in onCreate
- Clients passing `{ roomId: 'channel-1' }` will now only match rooms with that metadata

## Testing
- [x] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)