### PR TITLE
fix: align NPC ID schema with server-generated npc_ prefix

### DIFF
--- a/docs/aic/v0.1/aic-schema.json
+++ b/docs/aic/v0.1/aic-schema.json
@@ -9,6 +9,8 @@
     "IdRoom": { "type": "string", "pattern": "^[a-zA-Z0-9._-]{1,64}$" },
     "IdAgent": { "type": "string", "pattern": "^[a-zA-Z0-9._-]{1,64}$" },
     "IdEntity": { "type": "string", "pattern": "^(hum|agt|obj)_[a-zA-Z0-9._-]{1,64}$" },
+    "IdNpc": { "type": "string", "pattern": "^(npc_)?[a-z][a-z0-9-]{0,63}$" },
+    "IdEntityOrNpc": { "oneOf": [{ "$ref": "#/$defs/IdEntity" }, { "$ref": "#/$defs/IdNpc" }] },
     "IdTx": { "type": "string", "pattern": "^tx_[a-zA-Z0-9._-]{8,128}$" },
     "Cursor": { "type": "string", "pattern": "^[A-Za-z0-9=_-]{1,256}$" },
     "TsMs": { "type": "integer", "minimum": 0 },
@@ -128,7 +130,7 @@
       "additionalProperties": false,
       "required": ["id", "kind", "name", "pos", "roomId"],
       "properties": {
-        "id": { "$ref": "#/$defs/IdEntity" },
+        "id": { "$ref": "#/$defs/IdEntityOrNpc" },
         "kind": { "$ref": "#/$defs/EntityKind" },
         "name": { "type": "string", "minLength": 1, "maxLength": 64 },
         "roomId": { "$ref": "#/$defs/IdRoom" },

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -18,8 +18,11 @@ export const IdEntitySchema = z
   .string()
   .regex(/^(hum|agt|obj)_[a-zA-Z0-9._-]{1,64}$/, 'Invalid entityId format');
 
-// NPC ID schema - supports kebab-case NPC identifiers (e.g., 'greeter', 'meeting-host')
-export const IdNpcSchema = z.string().regex(/^[a-z][a-z0-9-]{0,63}$/, 'Invalid npcId format');
+// NPC ID schema - supports npc_ prefixed IDs (e.g., 'npc_greeter', 'npc_meeting-host')
+// and bare kebab-case identifiers (e.g., 'greeter', 'meeting-host')
+export const IdNpcSchema = z
+  .string()
+  .regex(/^(npc_)?[a-z][a-z0-9-]{0,63}$/, 'Invalid npcId format');
 
 // Entity or NPC ID schema - used in observe responses where both types can appear
 export const IdEntityOrNpcSchema = z.union([IdEntitySchema, IdNpcSchema]);


### PR DESCRIPTION
## Summary
- Update `IdNpcSchema` to accept both bare kebab-case (`greeter`) and `npc_` prefixed (`npc_greeter`) IDs matching actual server behavior
- Update `aic-schema.json` `EntityBase.id` to use `IdEntityOrNpc` union so schema validators accept NPCs in observe responses

## Context
Review feedback from PR #348 identified that `IdNpcSchema` only accepted `^[a-z][a-z0-9-]{0,63}$` but server generates NPC IDs as `npc_${npcDef.id}` (e.g., `npc_greeter`). Any schema-validating consumer would reject valid observe responses when NPCs are nearby.

## Test plan
- [x] All 1042 tests pass
- [x] Build succeeds
- [ ] Verify observe responses with NPCs nearby pass schema validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)