### PR TITLE
docs: fix map spec coordinates to use 1024 game space

### DIFF
--- a/docs/reference/map_spec_grid_town.md
+++ b/docs/reference/map_spec_grid_town.md
@@ -13,40 +13,40 @@ Based on reference image: `grid_town_layout.png`
 | Map Size (tiles) | 64 x 64 |
 | Actual Map Size (px) | 1024 x 1024 |
 
-> **Coordinate System Note:** All pixel coordinates in this document use the **2048x2048 reference image** coordinate space. To convert to in-game (1024x1024) coordinates:
-> - `game_px = reference_px × 0.5`
-> - Example: Reference (1024, 800) → Game (512, 400)
+> **Coordinate System Note:** All pixel coordinates in this document use **in-game (1024x1024) coordinates**, matching `packages/shared/src/world.ts`. The reference image is 2048x2048; multiply game coordinates by 2 to map back to the reference image.
 
 ## Zone Boundaries (8 Zones)
 
+Source of truth: `ZONE_BOUNDS` in `packages/shared/src/world.ts`
+
 | Zone | Zone ID | Pixel X | Pixel Y | Width | Height | Description |
 |------|---------|---------|---------|-------|--------|-------------|
-| Lobby | `lobby` | 192 | 64 | 384 | 384 | Reception, entrance, info boards |
-| Office | `office` | 1344 | 64 | 640 | 448 | Workstations, kanban board |
-| Central Park | `central-park` | 640 | 512 | 768 | 640 | Green space, benches, signpost |
-| Arcade | `arcade` | 1408 | 512 | 576 | 512 | Game cabinets, entertainment |
-| Meeting | `meeting` | 64 | 896 | 512 | 576 | Meeting rooms (Room A, Room C) |
-| Lounge Cafe | `lounge-cafe` | 576 | 1216 | 640 | 448 | Cafe counter, seating |
-| Plaza | `plaza` | 1216 | 1216 | 512 | 512 | Fountain, social hub |
-| Lake | `lake` | 64 | 64 | 128 | 448 | Water feature (blocked) |
+| Lobby | `lobby` | 96 | 32 | 192 | 192 | Reception, entrance, info boards |
+| Office | `office` | 672 | 32 | 320 | 224 | Workstations, kanban board |
+| Central Park | `central-park` | 320 | 256 | 384 | 320 | Green space, benches, signpost |
+| Arcade | `arcade` | 704 | 256 | 288 | 256 | Game cabinets, entertainment |
+| Meeting | `meeting` | 32 | 448 | 256 | 288 | Meeting rooms (Room A, Room C) |
+| Lounge Cafe | `lounge-cafe` | 288 | 608 | 320 | 224 | Cafe counter, seating |
+| Plaza | `plaza` | 608 | 608 | 256 | 256 | Fountain, social hub |
+| Lake | `lake` | 32 | 32 | 64 | 224 | Water feature (blocked) |
 
 ## Zone Layout (Visual)
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │  LAKE   │           LOBBY            │         OFFICE           │
-│  (64,64)│         (192,64)           │       (1344,64)          │
+│  (32,32)│         (96,32)            │       (672,32)           │
 │         │                            │                          │
 ├─────────┴────────────────────────────┼──────────────────────────┤
 │                                      │                          │
 │                                      │         ARCADE           │
-│              CENTRAL PARK            │       (1408,512)         │
-│                (640,512)             │                          │
+│              CENTRAL PARK            │       (704,256)          │
+│                (320,256)             │                          │
 │                                      │                          │
 ├──────────────────────────────────────┴──────────────────────────┤
 │                │                     │                          │
 │    MEETING     │    LOUNGE-CAFE      │         PLAZA            │
-│   (64,896)     │     (576,1216)      │       (1216,1216)        │
+│   (32,448)     │     (288,608)       │       (608,608)          │
 │                │                     │                          │
 └────────────────┴─────────────────────┴──────────────────────────┘
 ```
@@ -68,72 +68,72 @@ Based on reference image: `grid_town_layout.png`
 
 | Object | Type | Pixel Position | Interaction Radius |
 |--------|------|----------------|-------------------|
-| reception-desk | desk | (256, 192) | 48 |
-| info-board | board | (384, 128) | 32 |
+| reception-desk | desk | (128, 96) | 48 |
+| info-board | board | (192, 64) | 32 |
 
 ### Office
 
 | Object | Type | Pixel Position | Interaction Radius |
 |--------|------|----------------|-------------------|
-| kanban-board | board | (1728, 192) | 32 |
-| desk-cluster | desk | (1536, 288) | 48 |
-| whiteboard | board | (1856, 128) | 32 |
+| kanban-board | board | (864, 96) | 32 |
+| desk-cluster | desk | (768, 144) | 48 |
+| whiteboard | board | (928, 64) | 32 |
 
 ### Central Park
 
 | Object | Type | Pixel Position | Interaction Radius |
 |--------|------|----------------|-------------------|
-| signpost | sign | (992, 768) | 32 |
-| bench-park-1 | bench | (800, 640) | 32 |
-| bench-park-2 | bench | (1184, 960) | 32 |
+| signpost | sign | (496, 384) | 32 |
+| bench-park-1 | bench | (400, 320) | 32 |
+| bench-park-2 | bench | (592, 480) | 32 |
 
 ### Arcade
 
 | Object | Type | Pixel Position | Interaction Radius |
 |--------|------|----------------|-------------------|
-| arcade-cabinet-1 | game | (1472, 576) | 32 |
-| arcade-cabinet-2 | game | (1568, 576) | 32 |
-| arcade-cabinet-3 | game | (1664, 576) | 32 |
-| prize-counter | counter | (1600, 896) | 48 |
+| arcade-cabinet-1 | game | (736, 288) | 32 |
+| arcade-cabinet-2 | game | (784, 288) | 32 |
+| arcade-cabinet-3 | game | (832, 288) | 32 |
+| prize-counter | counter | (800, 448) | 48 |
 
 ### Meeting
 
 | Object | Type | Pixel Position | Interaction Radius |
 |--------|------|----------------|-------------------|
-| meeting-room-a | room | (192, 992) | 64 |
-| meeting-room-c | room | (192, 1248) | 64 |
-| schedule-board | board | (416, 992) | 32 |
-| whiteboard | board | (320, 1120) | 32 |
+| meeting-room-a | room | (96, 496) | 64 |
+| meeting-room-c | room | (96, 624) | 64 |
+| schedule-board | board | (208, 496) | 32 |
+| whiteboard | board | (160, 560) | 32 |
 
 ### Lounge Cafe
 
 | Object | Type | Pixel Position | Interaction Radius |
 |--------|------|----------------|-------------------|
-| cafe-counter | counter | (736, 1344) | 48 |
-| vending-machine | machine | (928, 1344) | 32 |
-| seating-area | seating | (800, 1536) | 64 |
+| cafe-counter | counter | (368, 672) | 48 |
+| vending-machine | machine | (464, 672) | 32 |
+| seating-area | seating | (400, 768) | 64 |
 
 ### Plaza
 
 | Object | Type | Pixel Position | Interaction Radius |
 |--------|------|----------------|-------------------|
-| fountain | decoration | (1440, 1440) | 64 |
-| bench-1 | bench | (1312, 1312) | 32 |
-| bench-2 | bench | (1568, 1568) | 32 |
+| fountain | decoration | (720, 720) | 64 |
+| bench-1 | bench | (656, 656) | 32 |
+| bench-2 | bench | (784, 784) | 32 |
 
 ## NPC Positions (9 NPCs)
 
 | NPC ID | Name | Zone | Pixel Position | Role |
 |--------|------|------|----------------|------|
-| greeter | Sam the Greeter | lobby | (320, 256) | Welcome/guide |
-| security | Max the Guard | lobby | (384, 192) | Security |
-| office-pm | Jordan the PM | office | (1600, 320) | Project management |
-| it-help | Casey IT Support | office | (1728, 256) | Tech support |
-| ranger | River the Ranger | central-park | (1024, 800) | Park management |
-| arcade-host | Drew the Game Master | arcade | (1600, 768) | Game host |
-| meeting-host | Alex the Coordinator | meeting | (288, 1120) | Meeting coordination |
-| barista | Jamie the Barista | lounge-cafe | (800, 1440) | Cafe service |
-| fountain-keeper | Quinn the Keeper | plaza | (1440, 1344) | Plaza maintenance |
+| greeter | Sam the Greeter | lobby | (160, 128) | Welcome/guide |
+| security | Max the Guard | lobby | (192, 96) | Security |
+| office-pm | Jordan the PM | office | (800, 160) | Project management |
+| it-help | Casey IT Support | office | (864, 128) | Tech support |
+| ranger | River the Ranger | central-park | (512, 400) | Park management |
+| arcade-host | Drew the Game Master | arcade | (800, 384) | Game host |
+| meeting-host | Alex the Coordinator | meeting | (144, 560) | Meeting coordination |
+| barista | Jamie the Barista | lounge-cafe | (400, 720) | Cafe service |
+| fountain-keeper | Quinn the Keeper | plaza | (720, 672) | Plaza maintenance |
 
 ## Building Entrances
 
@@ -141,21 +141,21 @@ Building entrances are defined in the map's objects layer with `type: "building_
 
 | Zone | Direction | Pixel Position | Connects To | Tile Position |
 |------|-----------|----------------|-------------|---------------|
-| lobby | south | (352, 416) | central-park | (11, 13) |
-| office | west | (1344, 256) | lobby/road | (42, 8) |
-| arcade | west | (1408, 736) | central-park | (44, 23) |
-| meeting | east | (544, 1152) | central-park | (17, 36) |
-| meeting | south | (320, 1440) | lounge-cafe | (10, 45) |
-| lounge-cafe | north | (864, 1216) | central-park | (27, 38) |
-| lounge-cafe | west | (576, 1472) | meeting | (18, 46) |
-| plaza | north | (1440, 1216) | central-park | (45, 38) |
+| lobby | south | (176, 208) | central-park | (11, 13) |
+| office | west | (672, 128) | lobby/road | (42, 8) |
+| arcade | west | (704, 368) | central-park | (44, 23) |
+| meeting | east | (272, 576) | central-park | (17, 36) |
+| meeting | south | (160, 720) | lounge-cafe | (10, 45) |
+| lounge-cafe | north | (432, 608) | central-park | (27, 38) |
+| lounge-cafe | west | (288, 736) | meeting | (18, 46) |
+| plaza | north | (720, 608) | central-park | (45, 38) |
 
 ### Zone Connectivity Diagram
 
 ```
          LOBBY ──→ road ←── OFFICE
-           ↓                
-           ↓                
+           ↓
+           ↓
     MEETING ←─→ CENTRAL-PARK ←─→ ARCADE
        ↓              ↓
        ↓              ↓
@@ -171,13 +171,13 @@ Building entrances are defined in the map's objects layer with `type: "building_
 
 | Zone | Spawn Position (px) | Notes |
 |------|---------------------|-------|
-| lobby | (320, 256) | Entry zone - default spawn |
-| office | (1600, 320) | Near kanban board |
-| central-park | (1024, 800) | Center of park |
-| arcade | (1600, 768) | Near game cabinets |
-| meeting | (288, 1120) | Between meeting rooms |
-| lounge-cafe | (800, 1440) | Near cafe counter |
-| plaza | (1440, 1440) | Near fountain |
+| lobby | (160, 128) | Entry zone - default spawn |
+| office | (800, 160) | Near kanban board |
+| central-park | (512, 400) | Center of park |
+| arcade | (800, 384) | Near game cabinets |
+| meeting | (144, 560) | Between meeting rooms |
+| lounge-cafe | (400, 720) | Near cafe counter |
+| plaza | (720, 720) | Near fountain |
 | lake | N/A | No spawn (blocked zone) |
 
 ## Layers


### PR DESCRIPTION
## Summary
- All pixel coordinates in `map_spec_grid_town.md` were using 2048 reference image values instead of 1024 in-game coordinates
- Updated all zone boundaries, facility positions, NPC positions, building entrances, and spawn points to match `ZONE_BOUNDS` in `world.ts`
- Clarified coordinate system note: in-game (1024x1024) coordinates are primary, multiply by 2 for reference image

## Context
Addresses gemini-code-assist and codex review feedback from PR #351 noting that "the pixel coordinates in the rest of this document have not been updated" after map size was changed to 1024x1024.

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All 1042 tests pass (`pnpm test`)
- [x] Coordinates verified against `ZONE_BOUNDS` in `packages/shared/src/world.ts`
- [ ] Spot-check NPC/facility positions match game behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)