### PR TITLE
fix(#364): preserve DialogueTree objects in NPC definition parser

### DIFF
--- a/packages/server/src/world/WorldPackLoader.ts
+++ b/packages/server/src/world/WorldPackLoader.ts
@@ -1216,7 +1216,11 @@ export class WorldPackLoader {
         x: position.x ?? 0,
         y: position.y ?? 0,
       },
-      dialogue: Array.isArray(raw.dialogue) ? raw.dialogue : [],
+      dialogue: Array.isArray(raw.dialogue)
+        ? raw.dialogue
+        : raw.dialogue && typeof raw.dialogue === 'object'
+          ? (raw.dialogue as NpcDefinition['dialogue'])
+          : undefined,
       schedule: Array.isArray(raw.schedule)
         ? raw.schedule.map(s => {
             const item = s as {


### PR DESCRIPTION
## Summary
Resolves #364

Fixes NPC dialogue returning "undefined" instead of actual dialogue text.

## Root Cause
`WorldPackLoader.parseNpcDefinition()` used `Array.isArray(raw.dialogue) ? raw.dialogue : []` which discarded `DialogueTree` objects (like `{ greeting: { text: "...", options: [...] } }`), converting them to empty arrays `[]`. When `handleNpcTalk()` then accessed `dialogue[Math.floor(Math.random() * 0)]` = `dialogue[0]` = `undefined`, it displayed `"undefined"` as the NPC's response.

## Changes
- **WorldPackLoader.ts**: Updated dialogue parsing to accept both `string[]` arrays and `DialogueTree` objects, setting `undefined` only when dialogue data is missing entirely

## Testing
- [x] Build passes
- [ ] NPC talk action returns proper dialogue tree (greeting node with options)

## Checklist
- [x] Code follows project conventions
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
  * NPC 대사 처리 개선 - 더 유연한 형식의 대사 데이터를 지원하도록 개선되었습니다. 이제 배열 형식뿐 아니라 다양한 형태의 대사 데이터를 올바르게 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->