### PR TITLE
fix: align AIC schema with Zod validation for skill types

### DIFF
--- a/docs/aic/v0.1/aic-schema.json
+++ b/docs/aic/v0.1/aic-schema.json
@@ -432,10 +432,10 @@
     "SkillAction": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "description"],
+      "required": ["id", "name", "description"],
       "properties": {
         "id": { "type": "string" },
-        "name": { "type": "string" },
+        "name": { "type": "string", "minLength": 1, "maxLength": 128 },
         "label": { "type": "string" },
         "description": { "type": "string" },
         "cooldownMs": { "type": "integer", "minimum": 0 },
@@ -517,7 +517,7 @@
         "agentId": { "$ref": "#/$defs/IdAgent" },
         "roomId": { "$ref": "#/$defs/IdRoom" },
         "txId": { "$ref": "#/$defs/IdTx" },
-        "skillId": { "type": "string" },
+        "skillId": { "type": "string", "minLength": 1, "maxLength": 64 },
         "credentials": { "type": "object", "additionalProperties": { "type": "string" } }
       }
     },
@@ -542,8 +542,8 @@
         "agentId": { "$ref": "#/$defs/IdAgent" },
         "roomId": { "$ref": "#/$defs/IdRoom" },
         "txId": { "$ref": "#/$defs/IdTx" },
-        "skillId": { "type": "string" },
-        "actionId": { "type": "string" },
+        "skillId": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "actionId": { "type": "string", "minLength": 1, "maxLength": 64 },
         "targetId": { "$ref": "#/$defs/IdEntity" },
         "params": { "type": "object", "additionalProperties": true }
       }
@@ -556,7 +556,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ok", "pending", "cancelled", "error"]
+          "enum": ["ok", "pending", "cancelled"]
         },
         "message": { "type": "string", "maxLength": 2000 },
         "data": { "type": "object", "additionalProperties": true },

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1032,7 +1032,7 @@ export type SkillActionParam = {
 
 export type SkillAction = {
   id: string;
-  name?: string;
+  name: string;
   label?: string;
   description: string;
   cooldownMs?: number;


### PR DESCRIPTION
## Summary
- Add `SkillAction.name` to required array with `minLength:1, maxLength:128` constraints (matches `SkillActionSchema` in `schemas.ts`)
- Add `minLength:1, maxLength:64` to `skillId`/`actionId` in `SkillInstallRequest` and `SkillInvokeRequest` (matches Zod validation)
- Remove impossible `"error"` from `SkillInvokeOutcome.type` enum in API schema (error outcomes are returned as HTTP error responses, never in success `SkillInvokeResponseData`)
- Fix `SkillAction.name` TypeScript type: `optional` → `required` to match Zod schema

## Context
Addresses gemini-code-assist (HIGH) and chatgpt-codex-connector (P2) review feedback on PR #352. The internal TypeScript/Zod types keep `'error'` in `SkillInvokeOutcomeType` since `SkillService` uses it internally before converting to HTTP error responses.

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All 1042 tests pass (`pnpm test`)
- [x] Verified `SkillService` still compiles with internal `'error'` outcome type
- [x] Schema constraints match `SkillActionSchema`, `SkillInstallRequestSchema`, `SkillInvokeRequestSchema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)