### PR TITLE
fix: correct spaced-grid tile count and autotile edge-blend logic

### DIFF
--- a/tools/analyze_spritesheet.py
+++ b/tools/analyze_spritesheet.py
@@ -62,8 +62,8 @@ def detect_sprites_grid(
     """Detect sprites using uniform grid extraction."""
     width, height = img.size
     step = tile_size + spacing
-    cols = width // step
-    rows = height // step
+    cols = (width + spacing) // step
+    rows = (height + spacing) // step
 
     sprites = []
     for row in range(rows):

--- a/tools/analyze_tileset.py
+++ b/tools/analyze_tileset.py
@@ -522,8 +522,8 @@ def analyze_tileset(
         cols = width // tile_size
         rows = height // tile_size
     else:
-        cols = width // step
-        rows = height // step
+        cols = (width + spacing) // step
+        rows = (height + spacing) // step
 
     total_tiles = cols * rows
     tiles: List[Dict[str, Any]] = []

--- a/tools/compare_tiles.py
+++ b/tools/compare_tiles.py
@@ -49,9 +49,9 @@ def extract_tiles_from_grid(
 
     step = tile_size + spacing
     if cols == 0:
-        cols = width // step if spacing > 0 else width // tile_size
+        cols = (width + spacing) // step if spacing > 0 else width // tile_size
     if rows == 0:
-        rows = height // step if spacing > 0 else height // tile_size
+        rows = (height + spacing) // step if spacing > 0 else height // tile_size
 
     tiles = []
     for row in range(rows):

--- a/tools/generate_tiles.py
+++ b/tools/generate_tiles.py
@@ -318,8 +318,8 @@ def batch_resize_tilemap(
     w, h = img.size
 
     from_step = from_size + spacing
-    cols = w // from_step if spacing > 0 else w // from_size
-    rows = h // from_step if spacing > 0 else h // from_size
+    cols = (w + spacing) // from_step if spacing > 0 else w // from_size
+    rows = (h + spacing) // from_step if spacing > 0 else h // from_size
 
     out_w = cols * to_size
     out_h = rows * to_size
@@ -712,8 +712,8 @@ def generate_autotile47_tile(
         m = mask[:, :, np.newaxis].astype(bool)
         piece = np.where(m, arr_b, arr_c)
         result.paste(Image.fromarray(piece.astype(np.uint8)), (0, 0))
-    elif has_n or has_w:
-        # Edge: dither blend
+    elif (has_n or has_w) and not tl_center:
+        # Edge: dither blend (only when not fully connected)
         direction = "top" if has_n and not has_w else "left" if has_w and not has_n else "corner_tl"
         tl_c = center.crop((0, 0, half_w, half_h))
         tl_b = bg.crop((0, 0, half_w, half_h))
@@ -743,7 +743,7 @@ def generate_autotile47_tile(
         m = mask[:, :, np.newaxis].astype(bool)
         piece = np.where(m, arr_b, arr_c)
         result.paste(Image.fromarray(piece.astype(np.uint8)), (half_w, 0))
-    elif has_n or has_e:
+    elif (has_n or has_e) and not tr_center:
         tr_c = center.crop((half_w, 0, w, half_h))
         tr_b = bg.crop((half_w, 0, w, half_h))
         if has_n and not has_e:
@@ -772,7 +772,7 @@ def generate_autotile47_tile(
         m = mask[:, :, np.newaxis].astype(bool)
         piece = np.where(m, arr_b, arr_c)
         result.paste(Image.fromarray(piece.astype(np.uint8)), (0, half_h))
-    elif has_s or has_w:
+    elif (has_s or has_w) and not bl_center:
         bl_c = center.crop((0, half_h, half_w, h))
         bl_b = bg.crop((0, half_h, half_w, h))
         if has_s and not has_w:
@@ -801,7 +801,7 @@ def generate_autotile47_tile(
         m = mask[:, :, np.newaxis].astype(bool)
         piece = np.where(m, arr_b, arr_c)
         result.paste(Image.fromarray(piece.astype(np.uint8)), (half_w, half_h))
-    elif has_s or has_e:
+    elif (has_s or has_e) and not br_center:
         br_c = center.crop((half_w, half_h, w, h))
         br_b = bg.crop((half_w, half_h, w, h))
         if has_s and not has_e:


### PR DESCRIPTION
## Summary
Two HIGH priority bug fixes from PR #392 review:

### 1. Spaced-grid floor division drops edge tiles (4 files)
- `width // (tile_size + spacing)` undercounts when spacing exists between tiles but no trailing gutter
- Fixed to `(width + spacing) // (tile_size + spacing)` which correctly counts the last column/row
- Example: 458px Kenney interior sheet with 16px tiles + 1px spacing now yields 27 cols instead of 26
- **Files**: `analyze_tileset.py`, `compare_tiles.py`, `analyze_spritesheet.py`, `generate_tiles.py`

### 2. Autotile quadrant edge-blend applied to fully-connected tiles
- `elif has_n or has_w:` was true even when all three neighbors (N, W, NW) are present
- This caused bitmask=255 (fully surrounded) quadrants to be dither-blended with background instead of pure center tile
- Added `not *_center` guard to all 4 quadrant elif branches
- **File**: `generate_tiles.py`

## Context
Addresses chatgpt-codex-connector P1 review feedback on PR #392 (tileset tooling).

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All 1042 tests pass (`pnpm test`)
- [x] Verified formula: `(458 + 1) // (16 + 1) = 27` (correct) vs `458 // 17 = 26` (wrong)
- [ ] Visual verification: run `analyze_tileset.py` on a spaced Kenney sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)