### PR TITLE
fix(#365): validate first movement step to prevent silent path rejection

### DIFF
--- a/packages/server/src/aic/handlers/moveTo.ts
+++ b/packages/server/src/aic/handlers/moveTo.ts
@@ -127,7 +127,10 @@ export async function handleMoveTo(req: Request, res: Response): Promise<void> {
       return;
     }
 
-    const result = movementSystem.setDestination(agentId, tx, ty);
+    const result = movementSystem.setDestination(agentId, tx, ty, {
+      x: agentEntity.pos.x,
+      y: agentEntity.pos.y,
+    });
 
     const responseData: MoveToResponseData = {
       txId,


### PR DESCRIPTION
## Summary
Resolves #365

Fixes the issue where `moveTo` returns 'accepted' but agent position never changes.

## Root Cause
`MovementSystem.setDestination()` only validated the **destination** tile (not blocked, in bounds), but `MovementSystem.update()` also checks **intermediate** tiles along the straight-line path. When an intermediate tile was blocked (wall, building), the movement was silently cancelled on the first tick — the agent never moved and received no error feedback.

## Changes
- **MovementSystem.ts**: `setDestination()` now accepts optional `currentPos` parameter; when provided, simulates one movement step to verify the first tile on the path isn't blocked
- **moveTo.ts**: Passes agent's current position to `setDestination()` so blocked paths return 'rejected' instead of 'accepted'

## Testing
- [x] Build passes
- [ ] Agent at spawn, moveTo to a tile behind a wall → returns 'rejected'
- [ ] Agent at spawn, moveTo to an open tile → returns 'accepted', position updates
- [ ] WebSocket move_to continues to work (no currentPos passed, backward-compatible)

## Checklist
- [x] Code follows project conventions
- [x] No breaking changes (currentPos parameter is optional)
- [x] Note: Full A* pathfinding (#370) would be a more complete solution for complex paths