### PR TITLE
refactor: deduplicate error handling in resident-agent-loop

### DIFF
--- a/scripts/resident-agent-loop.ts
+++ b/scripts/resident-agent-loop.ts
@@ -2812,16 +2812,7 @@ class ResidentAgent {
       this.recordApiCall('observe', startMs, true);
       this.state.lastAction = 'observe';
     } catch (error) {
-      const errMsg = error instanceof Error ? error.message : String(error);
-      this.recordApiCall('observe', startMs, false, {
-        httpStatusCode: httpStatus,
-        errorMessage: errMsg,
-        errorCode: httpStatus
-          ? httpStatus >= 500
-            ? 'server_error'
-            : 'client_error'
-          : 'network_error',
-      });
+      this.recordApiCall('observe', startMs, false, this.buildErrorDetails(httpStatus, error));
       throw error;
     }
   }
@@ -2849,16 +2840,7 @@ class ResidentAgent {
       this.recordApiCall('moveTo', startMs, true);
       this.state.lastAction = `moveTo(${tx}, ${ty})`;
     } catch (error) {
-      const errMsg = error instanceof Error ? error.message : String(error);
-      this.recordApiCall('moveTo', startMs, false, {
-        httpStatusCode: httpStatus,
-        errorMessage: errMsg,
-        errorCode: httpStatus
-          ? httpStatus >= 500
-            ? 'server_error'
-            : 'client_error'
-          : 'network_error',
-      });
+      this.recordApiCall('moveTo', startMs, false, this.buildErrorDetails(httpStatus, error));
       throw error;
     }
   }
@@ -2887,16 +2869,7 @@ class ResidentAgent {
       this.recordApiCall('chatSend', startMs, true);
       this.state.lastAction = `chat("${message.substring(0, 20)}...")`;
     } catch (error) {
-      const errMsg = error instanceof Error ? error.message : String(error);
-      this.recordApiCall('chatSend', startMs, false, {
-        httpStatusCode: httpStatus,
-        errorMessage: errMsg,
-        errorCode: httpStatus
-          ? httpStatus >= 500
-            ? 'server_error'
-            : 'client_error'
-          : 'network_error',
-      });
+      this.recordApiCall('chatSend', startMs, false, this.buildErrorDetails(httpStatus, error));
       throw error;
     }
   }
@@ -2940,16 +2913,7 @@ class ResidentAgent {
       }
       this.recordApiCall('chatObserve', startMs, true);
     } catch (error) {
-      const errMsg = error instanceof Error ? error.message : String(error);
-      this.recordApiCall('chatObserve', startMs, false, {
-        httpStatusCode: httpStatus,
-        errorMessage: errMsg,
-        errorCode: httpStatus
-          ? httpStatus >= 500
-            ? 'server_error'
-            : 'client_error'
-          : 'network_error',
-      });
+      this.recordApiCall('chatObserve', startMs, false, this.buildErrorDetails(httpStatus, error));
       throw error;
     }
   }
@@ -2991,16 +2955,7 @@ class ResidentAgent {
       this.state.lastAction = `interact(${targetId}, ${action})`;
       return outcome;
     } catch (error) {
-      const errMsg = error instanceof Error ? error.message : String(error);
-      this.recordApiCall('interact', startMs, false, {
-        httpStatusCode: httpStatus,
-        errorMessage: errMsg,
-        errorCode: httpStatus
-          ? httpStatus >= 500
-            ? 'server_error'
-            : 'client_error'
-          : 'network_error',
-      });
+      this.recordApiCall('interact', startMs, false, this.buildErrorDetails(httpStatus, error));
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- Replace 5 inline error classification blocks in `observe`, `moveTo`, `chatSend`, `chatObserve`, `interact` catch handlers with calls to the existing `buildErrorDetails()` helper
- Removes 50 lines of duplicated ternary logic (`httpStatus >= 500 ? 'server_error' : 'client_error' : 'network_error'`)
- The newer methods (`pollEvents`, `skillList`, `skillInstall`, `skillInvoke`) already used this helper, creating inconsistency

## Context
Addresses gemini-code-assist (MEDIUM) and coderabbitai (MAJOR refactor) feedback on PR #317.

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All 1042 tests pass (`pnpm test`)
- [x] Verified `buildErrorDetails()` produces identical output to the inline blocks
- [x] All 5 methods + 5 newer methods now use the same error classification path

🤖 Generated with [Claude Code](https://claude.com/claude-code)