### PR TITLE
feat(#371): add explicit heartbeat endpoint for agent keepalive

### DIFF
--- a/packages/server/src/aic/handlers/heartbeat.ts
+++ b/packages/server/src/aic/handlers/heartbeat.ts
@@ -1,0 +1,19 @@
+import type { Request, Response } from 'express';
+import type { HeartbeatRequest } from '@openclawworld/shared';
+import { AGENT_TIMEOUT_MS } from '../../constants.js';
+
+export function handleHeartbeat(req: Request, res: Response): void {
+  const body = req.validatedBody as HeartbeatRequest;
+
+  // Activity is already tracked by activityTrackerMiddleware.
+  // This endpoint simply acknowledges the heartbeat and returns the timeout config.
+  res.status(200).json({
+    status: 'ok',
+    data: {
+      agentId: body.agentId,
+      serverTsMs: Date.now(),
+      timeoutMs: AGENT_TIMEOUT_MS,
+      recommendedIntervalMs: Math.floor(AGENT_TIMEOUT_MS / 5),
+    },
+  });
+}

--- a/packages/server/src/aic/router.ts
+++ b/packages/server/src/aic/router.ts
@@ -15,6 +15,7 @@ import {
   MeetingListRequestSchema,
   MeetingJoinRequestSchema,
   MeetingLeaveRequestSchema,
+  HeartbeatRequestSchema,
 } from '@openclawworld/shared';
 import {
   authMiddleware,
@@ -46,6 +47,7 @@ import { handleChannels } from './handlers/channels.js';
 import { handleMeetingList } from './handlers/meetingList.js';
 import { handleMeetingJoin } from './handlers/meetingJoin.js';
 import { handleMeetingLeave } from './handlers/meetingLeave.js';
+import { handleHeartbeat } from './handlers/heartbeat.js';
 
 const router: Router = Router();
 
@@ -70,6 +72,8 @@ router.post(
   validateRequest(UnregisterRequestSchema),
   handleUnregister
 );
+
+router.post('/heartbeat', validateRequest(HeartbeatRequestSchema), handleHeartbeat);
 
 router.post('/observe', observeRateLimiter, validateRequest(ObserveRequestSchema), handleObserve);
 

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -475,6 +475,17 @@ export const UnregisterResponseDataSchema = z.object({
 });
 
 // ============================================================================
+// Heartbeat Schema
+// ============================================================================
+
+export const HeartbeatRequestSchema = z.object({
+  agentId: IdAgentSchema,
+  roomId: IdRoomSchema,
+});
+
+export type HeartbeatRequest = z.infer<typeof HeartbeatRequestSchema>;
+
+// ============================================================================
 // Status Tool Schemas
 // ============================================================================
 


### PR DESCRIPTION
## Summary
Resolves #371

Adds an explicit `/heartbeat` endpoint for agents to maintain presence without needing to call heavier endpoints like `/observe`.

## Changes
- **shared/schemas.ts**: Added `HeartbeatRequestSchema` (agentId + roomId)
- **handlers/heartbeat.ts**: New lightweight handler that acknowledges heartbeat and returns timeout config
- **router.ts**: Added `POST /heartbeat` route (authenticated, no rate limiter needed)

## Existing Keepalive Mechanism (Now Documented)
- `activityTrackerMiddleware` updates `lastActivityAt` on **every** authenticated AIC API call
- `cleanupStaleAgents()` runs every `AGENT_CLEANUP_INTERVAL_MS` (default: 60s, env configurable)
- Agents inactive for `AGENT_TIMEOUT_MS` (default: 300s, env configurable) are removed with `presence.leave` event

## Response Format
```json
{
  "status": "ok",
  "data": {
    "agentId": "agt_xxx",
    "serverTsMs": 1234567890,
    "timeoutMs": 300000,
    "recommendedIntervalMs": 60000
  }
}
```

## Testing
- [x] Build passes
- [ ] POST /heartbeat returns 200 with timeout config
- [ ] Activity tracker updates on heartbeat call

## Checklist
- [x] Code follows project conventions
- [x] No breaking changes