### PR TITLE
feat(#373): add collision grid to observe response for path pre-validation

### DIFF
--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -154,6 +154,7 @@ export const ObserveRequestSchema = z.object({
   radius: z.number().min(1).max(2000),
   detail: ObserveDetailSchema,
   includeSelf: z.boolean().optional(),
+  includeGrid: z.boolean().optional(),
 });
 
 export const MoveToRequestSchema = z.object({

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -99,6 +99,8 @@ export type ObserveRequest = {
   radius: number;
   detail: ObserveDetail;
   includeSelf?: boolean;
+  /** When true, includes collisionGrid in mapMetadata. Agents should cache this (grid is static). */
+  includeGrid?: boolean;
 };
 
 export type MoveToRequest = {
@@ -755,6 +757,8 @@ export type MapMetadata = {
   currentZone: ZoneId | null;
   zones: ZoneInfo[];
   mapSize: { width: number; height: number; tileSize: number };
+  /** Collision grid (row-major: grid[y][x], true=blocked). Included when includeGrid=true in observe request. */
+  collisionGrid?: boolean[][];
 };
 
 // Meetings


### PR DESCRIPTION
## Summary
Resolves #373

Adds collision grid data to the observe response so agents can pre-validate movement paths before calling moveTo.

## Changes
- **shared/types.ts**: Added `includeGrid` to `ObserveRequest`, `collisionGrid` to `MapMetadata`
- **shared/schemas.ts**: Added `includeGrid: z.boolean().optional()` to `ObserveRequestSchema`
- **observe.ts**: `buildMapMetadata()` now accepts `includeGrid` flag; when true, includes `collisionGrid` from `CollisionSystem.getGrid()`

## Usage
```json
POST /observe
{
  "agentId": "agt_xxx",
  "roomId": "channel1",
  "radius": 500,
  "detail": "full",
  "includeGrid": true
}
```

Response includes `mapMetadata.collisionGrid` (boolean[][], row-major, `grid[y][x]`, `true` = blocked). Agents should cache this as the grid is static per map.

## Testing
- [x] Build passes
- [ ] Observe with includeGrid=true returns collision grid
- [ ] Observe without includeGrid returns no grid (backward-compatible)
- [ ] Grid matches actual collision data

## Checklist
- [x] Code follows project conventions
- [x] No breaking changes (includeGrid is optional, defaults to not included)