### PR TITLE
feat(#372): add session recovery via POST /reconnect endpoint

### DIFF
--- a/packages/server/src/aic/handlers/reconnect.ts
+++ b/packages/server/src/aic/handlers/reconnect.ts
@@ -1,0 +1,124 @@
+import type { Request, Response } from 'express';
+import { randomBytes } from 'node:crypto';
+import { matchMaker } from 'colyseus';
+import type {
+  ReconnectRequest,
+  ReconnectResponseData,
+  AicErrorObject,
+} from '@openclawworld/shared';
+import type { GameRoom } from '../../rooms/GameRoom.js';
+import { getColyseusRoomId } from '../roomRegistry.js';
+import { getAgentIdFromToken, getRoomIdFromToken, registerToken } from '../tokenRegistry.js';
+
+function generateSessionToken(): string {
+  return `tok_${randomBytes(24).toString('base64url')}`;
+}
+
+function createErrorResponse(
+  code: AicErrorObject['code'],
+  message: string,
+  retryable: boolean
+): { status: 'error'; error: AicErrorObject } {
+  return {
+    status: 'error',
+    error: {
+      code,
+      message,
+      retryable,
+    },
+  };
+}
+
+export async function handleReconnect(req: Request, res: Response): Promise<void> {
+  const body = req.validatedBody as ReconnectRequest;
+  const { agentId, sessionToken } = body;
+
+  try {
+    // Validate the provided token matches the agent
+    const tokenAgentId = getAgentIdFromToken(sessionToken);
+
+    if (!tokenAgentId || tokenAgentId !== agentId) {
+      res
+        .status(401)
+        .json(
+          createErrorResponse(
+            'unauthorized',
+            'Invalid or expired session token. Please re-register via POST /register.',
+            false
+          )
+        );
+      return;
+    }
+
+    const roomId = getRoomIdFromToken(sessionToken);
+    if (!roomId) {
+      res
+        .status(401)
+        .json(
+          createErrorResponse(
+            'unauthorized',
+            'Session token has no associated room. Please re-register.',
+            false
+          )
+        );
+      return;
+    }
+
+    const colyseusRoomId = getColyseusRoomId(roomId);
+    if (!colyseusRoomId) {
+      res
+        .status(404)
+        .json(createErrorResponse('not_found', `Room '${roomId}' no longer exists`, false));
+      return;
+    }
+
+    const gameRoom = matchMaker.getLocalRoomById(colyseusRoomId) as GameRoom | undefined;
+    if (!gameRoom) {
+      res
+        .status(503)
+        .json(createErrorResponse('room_not_ready', `Room '${roomId}' is not ready`, true));
+      return;
+    }
+
+    const agentEntity = gameRoom.state.getEntity(agentId);
+    if (!agentEntity) {
+      res
+        .status(410)
+        .json(
+          createErrorResponse(
+            'agent_not_in_room',
+            `Agent '${agentId}' session has expired and was cleaned up. Please re-register.`,
+            false
+          )
+        );
+      return;
+    }
+
+    // Agent exists and token is valid — issue new token and reset activity
+    const newToken = generateSessionToken();
+    registerToken(newToken, agentId, roomId);
+    agentEntity.updateActivity();
+
+    const responseData: ReconnectResponseData = {
+      agentId,
+      roomId,
+      sessionToken: newToken,
+      pos: agentEntity.pos.toVec2(),
+      tile: agentEntity.tile?.toTileCoord(),
+    };
+
+    console.log(`[ReconnectHandler] Agent '${agentId}' reconnected to room '${roomId}'`);
+
+    res.status(200).json({
+      status: 'ok',
+      data: responseData,
+    });
+  } catch (error) {
+    console.error(`[ReconnectHandler] Error processing reconnect request:`, error);
+    res
+      .status(500)
+      .json(
+        createErrorResponse('internal', 'Internal server error processing reconnect request', true)
+      );
+  }
+}

--- a/packages/server/src/aic/router.ts
+++ b/packages/server/src/aic/router.ts
@@ -8,6 +8,7 @@ import {
   PollEventsRequestSchema,
   RegisterRequestSchema,
   UnregisterRequestSchema,
+  ReconnectRequestSchema,
   ProfileUpdateRequestSchema,
   SkillListRequestSchema,
   SkillInstallRequestSchema,
@@ -48,6 +49,7 @@ import { handleMeetingList } from './handlers/meetingList.js';
 import { handleMeetingJoin } from './handlers/meetingJoin.js';
 import { handleMeetingLeave } from './handlers/meetingLeave.js';
 import { handleHeartbeat } from './handlers/heartbeat.js';
+import { handleReconnect } from './handlers/reconnect.js';
 
 const router: Router = Router();
 
@@ -60,6 +62,14 @@ router.post(
   interactRateLimiter,
   validateRequest(RegisterRequestSchema),
   handleRegister
+);
+
+// Reconnect endpoint is UNAUTHENTICATED - validates old token manually
+router.post(
+  '/reconnect',
+  interactRateLimiter,
+  validateRequest(ReconnectRequestSchema),
+  handleReconnect
 );
 
 // All routes below require authentication

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -474,6 +474,19 @@ export const UnregisterResponseDataSchema = z.object({
   unregisteredAt: TsMsSchema,
 });
 
+export const ReconnectRequestSchema = z.object({
+  agentId: IdAgentSchema,
+  sessionToken: z.string().min(8),
+});
+
+export const ReconnectResponseDataSchema = z.object({
+  agentId: IdEntitySchema,
+  roomId: IdRoomSchema,
+  sessionToken: z.string(),
+  pos: z.object({ x: z.number(), y: z.number() }),
+  tile: z.object({ tx: z.number(), ty: z.number() }).optional(),
+});
+
 // ============================================================================
 // Heartbeat Schema
 // ============================================================================

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -449,6 +449,19 @@ export type UnregisterResponseData = {
   unregisteredAt: number;
 };
 
+export type ReconnectRequest = {
+  agentId: string;
+  sessionToken: string;
+};
+
+export type ReconnectResponseData = {
+  agentId: string;
+  roomId: string;
+  sessionToken: string;
+  pos: Vec2;
+  tile?: TileCoord;
+};
+
 // ============================================================================
 // Status Tool Types
 // ============================================================================


### PR DESCRIPTION
## Summary
Resolves #372

Adds a `POST /reconnect` endpoint that allows agents to recover their session after a network disconnection without re-registering.

## Changes
- **New** `packages/server/src/aic/handlers/reconnect.ts` — Reconnect handler that validates old session token, issues new token, resets activity timer
- **Modified** `packages/server/src/aic/router.ts` — Added `/reconnect` route (unauthenticated, validates token manually)
- **Modified** `packages/shared/src/types.ts` — Added `ReconnectRequest` and `ReconnectResponseData` types
- **Modified** `packages/shared/src/schemas.ts` — Added `ReconnectRequestSchema` and `ReconnectResponseDataSchema`

## Flow
```
Agent disconnects → within 5 min grace period (AGENT_TIMEOUT_MS)
Agent calls POST /reconnect { agentId, sessionToken }
  → Token valid + entity exists → New token issued, activity reset, returns pos/tile
  → Token valid + entity gone → 410 Gone (must re-register)
  → Token invalid → 401 Unauthorized (must re-register)
```

## Test plan
- [ ] Reconnect within grace period restores session with new token
- [ ] Old token is invalidated after reconnect
- [ ] Reconnect after entity cleanup returns 410
- [ ] Invalid token returns 401
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 세션 재연결 기능이 추가되었습니다. 사용자는 기존 세션을 재검증하여 새로운 인증 토큰을 획득할 수 있습니다.
* 재연결 중 에이전트의 위치 정보와 타일 좌표가 유지됩니다.
* 재연결 요청에 대한 보안 검증과 요청 빈도 제한이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->