### PR TITLE
fix(#406, #407): env-based server port and channel-full error handling

### DIFF
--- a/packages/client/.env.example
+++ b/packages/client/.env.example
@@ -1,0 +1,2 @@
+# Server port for AIC REST API and Colyseus WebSocket
+VITE_SERVER_PORT=2567

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -103,7 +103,16 @@ joinBtn.addEventListener('click', async () => {
     console.error('Failed to connect:', error);
     joinBtn.disabled = false;
     joinBtn.textContent = 'Join World';
-    alert('Failed to connect to server');
+    const msg = error instanceof Error ? error.message : String(error);
+    if (msg.includes('full') || msg.includes('Channel is full')) {
+      alert('선택한 채널이 가득 찼습니다. 다시 채널을 선택해 주세요.');
+      nameInputDiv.style.display = 'none';
+      channelSelectDiv.style.display = 'block';
+      selectedChannelId = null;
+      void loadChannels();
+    } else {
+      alert('연결에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
Fixes #406 and #407

- **#406**: Replace hardcoded port `2567` with `VITE_SERVER_PORT` env variable in both `getServerEndpoint()` and `fetchChannels()`. Add `.env.example` with default value.
- **#407**: Improve join error handler to distinguish channel-full errors from other failures. On channel-full: show Korean alert, redirect back to channel selection screen, and refresh the channel list.

## Test plan
- [x] `pnpm build` passes
- [ ] Verify `VITE_SERVER_PORT=3000` env changes the connection port
- [ ] Verify channel-full error shows the redirect alert and goes back to channel selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 연결 실패 시 상황별 오류 메시지를 한국어로 표시
* 채널이 가득 찬 경우 다시 선택할 수 있도록 UI 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->