### PR TITLE
fix: Meeting 핸들러 IDOR 취약점 - agentId 인증 검증 추가 (#506)

### DIFF
--- a/packages/server/src/aic/handlers/meetingJoin.ts
+++ b/packages/server/src/aic/handlers/meetingJoin.ts
@@ -25,6 +25,11 @@ export async function handleMeetingJoin(req: Request, res: Response): Promise<vo
   const body = req.validatedBody as MeetingJoinRequest;
   const { agentId, roomId, meetingId } = body;
 
+  if (req.authAgentId !== agentId) {
+    res.status(403).json(createErrorResponse('forbidden', 'Token does not match agentId', false));
+    return;
+  }
+
   try {
     // Verify the agent exists in the game room
     const colyseusRoomId = getColyseusRoomId(roomId);

--- a/packages/server/src/aic/handlers/meetingLeave.ts
+++ b/packages/server/src/aic/handlers/meetingLeave.ts
@@ -25,6 +25,11 @@ export async function handleMeetingLeave(req: Request, res: Response): Promise<v
   const body = req.validatedBody as MeetingLeaveRequest;
   const { agentId, roomId, meetingId } = body;
 
+  if (req.authAgentId !== agentId) {
+    res.status(403).json(createErrorResponse('forbidden', 'Token does not match agentId', false));
+    return;
+  }
+
   try {
     const colyseusRoomId = getColyseusRoomId(roomId);
     if (!colyseusRoomId) {

--- a/tests/contracts/meetingJoin.test.ts
+++ b/tests/contracts/meetingJoin.test.ts
@@ -173,6 +173,20 @@ describe('MeetingJoin Endpoint Contract Tests', () => {
       expectErrorResult(result, 'unauthorized');
     });
 
+    it('returns forbidden error when token agentId does not match body agentId', async () => {
+      mockServer.setHandler('/meeting/join', () =>
+        jsonResponse(createErrorResult('forbidden', 'Token does not match agentId', false), 403)
+      );
+
+      const result = await client.meetingJoin({
+        agentId: 'agt_victim',
+        roomId: 'test_room',
+        meetingId: 'mtg_001',
+      });
+
+      expectErrorResult(result, 'forbidden');
+    });
+
     it('returns internal error on server failure', async () => {
       mockServer.setHandler('/meeting/join', () =>
         jsonResponse(createErrorResult('internal', 'Internal server error', true), 500)

--- a/tests/contracts/meetingLeave.test.ts
+++ b/tests/contracts/meetingLeave.test.ts
@@ -169,6 +169,20 @@ describe('MeetingLeave Endpoint Contract Tests', () => {
       expectErrorResult(result, 'unauthorized');
     });
 
+    it('returns forbidden error when token agentId does not match body agentId', async () => {
+      mockServer.setHandler('/meeting/leave', () =>
+        jsonResponse(createErrorResult('forbidden', 'Token does not match agentId', false), 403)
+      );
+
+      const result = await client.meetingLeave({
+        agentId: 'agt_victim',
+        roomId: 'test_room',
+        meetingId: 'mtg_001',
+      });
+
+      expectErrorResult(result, 'forbidden');
+    });
+
     it('returns internal error on server failure', async () => {
       mockServer.setHandler('/meeting/leave', () =>
         jsonResponse(createErrorResult('internal', 'Internal server error', true), 500)


### PR DESCRIPTION
## Summary
- `handleMeetingJoin`에 `req.authAgentId !== agentId` 가드 추가
- `handleMeetingLeave`에 `req.authAgentId !== agentId` 가드 추가
- 두 엔드포인트 모두 `forbidden` contract 테스트 케이스 추가

## Issue
Closes #506

## Security Context
유효한 토큰을 가진 Agent A가 request body에 `agentId: "agt_victim"`을 넣어
다른 에이전트의 미팅 참가/퇴장을 수행할 수 있던 IDOR 취약점을 수정합니다.

기존에 검증이 있는 핸들러(`unregister`, `skillInstall`, `skillInvoke`, `skillList`)와
동일한 패턴으로 통일합니다.

## Local CI
- [x] lint passed
- [x] format passed
- [x] build passed
- [x] typecheck passed
- [x] tests passed (1196 tests)

## Test plan
- [x] `forbidden` 시나리오: token의 agentId와 body의 agentId가 다를 때 403 반환
- [x] 기존 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 회의 참여 및 퇴장 작업에 검증 확인을 추가했습니다.

* **테스트**
  * 회의 작업 검증 시나리오에 대한 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->