### PR TITLE
fix: self-hosted runner Python 버전 관리 표준화 (#512)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   NODE_VERSION: '22'
+  PYTHON_VERSION: '3.12'
 
 jobs:
   # ─── Group 0: All parallel, no inter-dependencies ──────────────────────────
@@ -404,21 +405,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Setup Python & Install schemathesis
+      - name: Setup Python ${{ env.PYTHON_VERSION }} & Install schemathesis
         run: |
-          # Ensure Python 3.10+ is available (schemathesis v4 requirement)
-          PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "0.0")
-          PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
-          PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
-          if [ "$PYTHON_MAJOR" -lt 3 ] || { [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -lt 10 ]; }; then
-            echo "Python $PYTHON_VERSION too old, installing 3.12 via brew..."
-            brew install python@3.12
-            export PATH="$(brew --prefix python@3.12)/libexec/bin:$PATH"
-            echo "$(brew --prefix python@3.12)/libexec/bin" >> $GITHUB_PATH
+          # self-hosted runner requirement: Node 22+, Python 3.10+
+          # Always use versioned brew Python to avoid macOS Xcode bundle (3.9)
+          if ! brew list "python@${{ env.PYTHON_VERSION }}" &>/dev/null; then
+            echo "Installing Python ${{ env.PYTHON_VERSION }} via brew..."
+            brew install "python@${{ env.PYTHON_VERSION }}"
           fi
+          BREW_PYTHON_BIN="$(brew --prefix "python@${{ env.PYTHON_VERSION }}")/libexec/bin"
+          export PATH="$BREW_PYTHON_BIN:$PATH"
+          echo "$BREW_PYTHON_BIN" >> "$GITHUB_PATH"
+          python3 --version
           python3 -m pip install --user --break-system-packages schemathesis 2>/dev/null \
             || python3 -m pip install --user schemathesis
-          echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
+          echo "$(python3 -m site --user-base)/bin" >> "$GITHUB_PATH"
 
       - name: Run API fuzzing
         run: bash scripts/schemathesis-fuzz.sh


### PR DESCRIPTION
## Summary
- `api-fuzz` 잡의 Python 설정을 항상 brew Python 3.12를 사용하도록 표준화
- 조건부 버전 체크 → 무조건 versioned brew Python 사용으로 변경
- 워크플로우 레벨에 `PYTHON_VERSION: '3.12'` env 변수 추가

## Issue
Closes #512

## Problem
macOS self-hosted runner의 시스템 Python이 Xcode 번들 3.9 (schemathesis v4는 3.10+ 필요).
기존 코드는 버전 체크 후 필요한 경우에만 brew 설치 → 조건 분기가 복잡하고 
향후 동일 문제 재발 가능.

## Solution
- 조건 체크 제거: 항상 `brew install python@3.12` (이미 설치된 경우 no-op)
- `BREW_PYTHON_BIN` 변수를 명시적으로 선언하고 PATH에 우선 추가
- `GITHUB_PATH` append 시 인용 부호 추가 (shellcheck 준수)
- 러너 요구사항을 인라인 코멘트로 문서화: "Node 22+, Python 3.10+"

## Local CI
- [x] actionlint: 경고 없음 (기존 pre-existing 경고도 해결됨)
- [x] lint passed
- [x] tests passed (1194 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)