### PR TITLE
fix: ensure zod-to-openapi is installed in production runtime

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,10 +18,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^8.4.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@asteasolutions/zod-to-openapi": "^8.4.1",
     "typescript": "^5.4.0",
     "vitest": "^4.0.18"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,13 +180,13 @@ importers:
 
   packages/shared:
     dependencies:
+      '@asteasolutions/zod-to-openapi':
+        specifier: ^8.4.1
+        version: 8.4.1(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
-      '@asteasolutions/zod-to-openapi':
-        specifier: ^8.4.1
-        version: 8.4.1(zod@4.3.6)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3


### PR DESCRIPTION
## Summary
- move `@asteasolutions/zod-to-openapi` from `devDependencies` to `dependencies` in `packages/shared/package.json`
- update `pnpm-lock.yaml` so production installs include the runtime import chain used by shared schemas
- keep infra repository local-only as requested; no infra files are included in this PR

## Why
`packages/shared/dist/schemas.js` imports and executes `extendZodWithOpenApi` at runtime. With production-only installs, keeping the package in `devDependencies` caused `ERR_MODULE_NOT_FOUND` in the world server container.

## Verification
- rebuilt `world-server` image with production install stage (`pnpm install --prod`) and confirmed container health
- verified endpoints return 200:
  - `http://127.0.0.1:2567/health` (world-server)
  - `http://127.0.0.1:5173/` (world-client)
  - `http://127.0.0.1:5179/api/office/snapshot` (office)
- ran `pnpm --filter @openclawworld/shared typecheck` successfully
- note: `pnpm --filter @openclawworld/server typecheck` has pre-existing failures unrelated to this diff on current upstream main