### PR TITLE
fix: schemathesis before_call 3-arg signature and rate-limit IPv6 validation

### DIFF
--- a/packages/server/src/aic/middleware/rateLimit.ts
+++ b/packages/server/src/aic/middleware/rateLimit.ts
@@ -1,16 +1,10 @@
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import type { Request, Response } from 'express';
 import type { AicErrorCode } from '@openclawworld/shared';
 
-function normalizeIpv6(ip: string): string {
-  if (!ip.includes(':')) return ip;
-  return ip.split(':').slice(0, 4).join(':');
-}
-
 function getClientKey(req: Request): string {
   if (req.authToken) return req.authToken;
-  const ip = req.ip ?? 'unknown';
-  return normalizeIpv6(ip);
+  return ipKeyGenerator(req.ip ?? '::1');
 }
 
 export const RateLimits = {

--- a/tests/schemathesis/hooks.py
+++ b/tests/schemathesis/hooks.py
@@ -50,7 +50,7 @@ def setup() -> None:
 
 
 @schemathesis.hook
-def before_call(context, case):
+def before_call(context, case, kwargs):
     """Inject auth credentials and valid agent/room IDs before each request."""
     if _session_token is None:
         setup()


### PR DESCRIPTION
## Summary

Fixes two CI failures in the **API Fuzzing (schemathesis)** job on main.

### 원인 1: `TypeError: Hook 'before_call' takes 3 arguments but 2 is defined`

schemathesis 4.10.2에서 `before_call` 훅 스펙이 변경되어 3개의 인수를 요구합니다.

```python
# 변경 전 (schemathesis이 import 시점에 TypeError 발생)
def before_call(context, case):

# 변경 후
def before_call(context, case, kwargs):  # kwargs: transport options dict
```

`kwargs`는 HTTP 클라이언트에 전달되는 transport 옵션 딕셔너리이며, 우리 훅에서는 사용하지 않지만 시그니처 검증 통과를 위해 선언해야 합니다.

### 원인 2: `ValidationError: ERR_ERL_KEY_GEN_IPV6`

express-rate-limit v8은 `keyGenerator.toString()`을 정적 분석하여 `req.ip`를 쓰면서 `ipKeyGenerator()` helper를 호출하지 않으면 `ValidationError`를 throw합니다.

```typescript
// 변경 전: req.ip를 직접 사용 → ValidationError 9회 반복 출력
import rateLimit from 'express-rate-limit';
function normalizeIpv6(ip: string): string { ... }
function getClientKey(req: Request): string {
  if (req.authToken) return req.authToken;
  return normalizeIpv6(req.ip ?? 'unknown');
}

// 변경 후: 공식 helper 사용 → 검증 통과
import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
function getClientKey(req: Request): string {
  if (req.authToken) return req.authToken;
  return ipKeyGenerator(req.ip ?? '::1');
}
```

## Local CI

- [x] lint passed
- [x] format:check passed
- [x] build passed
- [x] typecheck passed
- [x] test passed (53 test files, 1196 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 요청 속도 제한 시스템의 내부 구조를 개선하여 더욱 견고하게 만들었습니다.
  * 테스트 인프라 업데이트를 통해 자동화된 검증 프로세스를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->