### PR TITLE
fix(schemathesis): use /aic/v0.1 prefix in base URL

### DIFF
--- a/scripts/schemathesis-fuzz.sh
+++ b/scripts/schemathesis-fuzz.sh
@@ -72,7 +72,7 @@ export PYTHONPATH="${HOOKS_DIR}:${PYTHONPATH:-}"
 FUZZ_EXIT=0
 schemathesis run "${BASE_URL}/openapi.json" \
   --checks all \
-  --url "${BASE_URL}" \
+  --url "${BASE_URL}/aic/v0.1" \
   --max-examples "${MAX_EXAMPLES}" \
   --request-timeout 10000 \
   --workers 1 \


### PR DESCRIPTION
## 근본 원인

`schemathesis-fuzz.sh`의 `--url` 플래그는 OpenAPI spec의 `servers[].url` 필드를 **완전히 override**합니다.

기존 코드:
```bash
--url "${BASE_URL}"   # = http://localhost:2567
```

OpenAPI spec에 정의된 서버:
```json
"servers": [{ "url": "http://localhost:2567/aic/v0.1" }]
```

결과: schemathesis가 `/chatObserve`, `/observe` 등의 경로를 `http://localhost:2567/chatObserve`로 전송 → 모든 엔드포인트에서 **404** 반환

이로 인해 발생한 거짓 실패:
- `❌ Missing header not rejected: 16` — 401 대신 404 반환
- `❌ Undocumented HTTP status code: 16` — 404가 스펙에 없음
- `❌ Unsupported methods: 2` — 405 대신 404 반환
- `⚠️ Missing valid test data: 9` — 모든 operation이 404 반환

## 수정 내용

```bash
# 변경 전
--url "${BASE_URL}" \

# 변경 후
--url "${BASE_URL}/aic/v0.1" \
```

base URL에 `/aic/v0.1`을 추가해 OpenAPI spec의 `servers[0].url`과 일치시킵니다.

## 영향

- `/aic/v0.1/chatObserve`, `/aic/v0.1/register` 등 정확한 경로로 요청 전송
- 인증 없는 요청 → 401 응답 (올바름)
- 지원하지 않는 메서드 → 405 응답 (올바름)

## Local CI
- [x] lint + format: ✅ (bash 스크립트, TS 변경 없음)
- [x] typecheck: ✅ (변경 없음)
- [x] test: ✅ (변경 없음)
- [x] build: ✅ (변경 없음)

Closes the ongoing API Fuzzing failure that started after PR #522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
  * 퍼징 테스트 대상 경로를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->