### PR TITLE
fix: exclude auto-generated Colyseus schemas from CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: CodeQL Configuration
+
+# Exclude auto-generated files from CodeQL analysis.
+# Colyseus schema codegen emits a fixed import line covering all possible
+# types regardless of which are used in a given schema class, causing
+# spurious js/unused-local-variable alerts for every generated file.
+paths-ignore:
+  - 'packages/client/src/generated/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4


### PR DESCRIPTION
## Summary

- Add `.github/codeql/codeql-config.yml` with `paths-ignore` for `packages/client/src/generated/**`
- Reference the config file in `.github/workflows/codeql.yml`

## Issue

Closes #532

All 23 open code scanning alerts were `js/unused-local-variable` (severity: note) in auto-generated Colyseus schema files. The generator emits a fixed import line including `ArraySchema`, `MapSchema`, `SetSchema`, and `DataChange` regardless of which types are used in a given schema — this is expected codegen behavior.

## Local CI

- [x] actionlint passed
- [x] lint + format passed
- [x] typecheck passed (no TS changes)
- [x] build passed (no code changes)

## Test plan

- After CodeQL re-scan, 0 alerts should appear in `packages/client/src/generated/`
- All 23 existing alerts have been dismissed as false positives pending the config fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* CodeQL 보안 스캔 설정 개선으로 자동 생성 코드 관련 거짓 양성 감소

<!-- end of auto-generated comment: release notes by coderabbit.ai -->