### PR TITLE
fix(#528): return HTTP 400 for unsupported chat channels instead of silent no-op

### DIFF
--- a/packages/server/src/aic/handlers/chatSend.ts
+++ b/packages/server/src/aic/handlers/chatSend.ts
@@ -52,16 +52,15 @@ export async function handleChatSend(req: Request, res: Response): Promise<void>
     }
 
     if (!VALID_CHANNELS.includes(channel as (typeof VALID_CHANNELS)[number])) {
-      const responseData: ChatSendResponseData = {
-        txId,
-        applied: false,
-        serverTsMs: Date.now(),
-      };
-      chatSendIdempotencyStore.save(agentId, roomId, txId, body, responseData);
-      res.status(200).json({
-        status: 'ok',
-        data: responseData,
-      });
+      res
+        .status(400)
+        .json(
+          createErrorResponse(
+            'bad_request',
+            `Channel '${channel}' is not supported. Supported channels: ${VALID_CHANNELS.join(', ')}`,
+            false
+          )
+        );
       return;
     }
 


### PR DESCRIPTION
## Summary
- `chatSend` now returns HTTP 400 with `bad_request` error code when called with unsupported channels (`team`, `meeting`, `dm`)
- Previously returned HTTP 200 with `applied: false` and empty `chatMessageId`, a silent no-op that violated the API contract

## Issue
Closes #528

## Root cause
`VALID_CHANNELS = ['proximity', 'global']` but `ChatChannelSchema` exposes `team/meeting/dm` too. The mismatch was silently handled by returning success with `applied: false`, giving callers no indication the channel is unsupported.

## Local CI
- [x] lint passed
- [x] format passed
- [x] typecheck passed
- [x] test passed (1196/1196)
- [x] build passed

## Test plan
- Call `chatSend` with `channel: team` → expect HTTP 400 with `bad_request`
- Call `chatSend` with `channel: proximity` → expect HTTP 200 with `applied: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)