### PR TITLE
fix(#527): resolve proximity chat delivery to human WebSocket clients

### DIFF
--- a/packages/server/src/aic/handlers/chatSend.ts
+++ b/packages/server/src/aic/handlers/chatSend.ts
@@ -140,7 +140,9 @@ export async function handleChatSend(req: Request, res: Response): Promise<void>
       const senderPos = agentEntity.pos;
 
       gameRoom.clients.forEach(client => {
-        const clientEntity = gameRoom.state.getEntity(client.sessionId);
+        const entityId = gameRoom.getEntityIdForSession(client.sessionId);
+        if (!entityId) return;
+        const clientEntity = gameRoom.state.getEntity(entityId);
         if (!clientEntity) return;
 
         const dx = clientEntity.pos.x - senderPos.x;

--- a/packages/server/src/rooms/GameRoom.ts
+++ b/packages/server/src/rooms/GameRoom.ts
@@ -374,6 +374,10 @@ export class GameRoom extends Room<{ state: RoomState }> {
     return this.state.humans.size + this.state.agents.size;
   }
 
+  getEntityIdForSession(sessionId: string): string | undefined {
+    return this.clientEntities.get(sessionId);
+  }
+
   handleInteraction(
     agentId: string,
     targetId: string,


### PR DESCRIPTION
## Summary
- Add `GameRoom.getEntityIdForSession(sessionId)` getter backed by the existing `clientEntities` Map
- Fix proximity broadcast in `chatSend.ts` to use session→entityId lookup before calling `state.getEntity()`
- Previously, `state.getEntity(client.sessionId)` always returned `undefined` (entities keyed by entityId, not session), so no human client ever received proximity messages from agents

## Issue
Closes #527

## Root cause
`clientEntities: Map<string, string>` maps `sessionId → entityId`. Human entities are keyed as `hum_*` in `state`, not by session ID. The old code `state.getEntity(client.sessionId)` was the wrong lookup.

## Local CI
- [x] lint passed
- [x] format passed
- [x] typecheck passed
- [x] test passed (1196/1196)
- [x] build passed

## Test plan
- Register agent in channel-1
- Connect 2 human WebSocket clients to the same room
- Send proximity chatSend from agent
- Verify nearby humans receive `chat` event on their WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)