### PR TITLE
fix(#526): use canonical Kenney players atlas as primary avatar renderer

### DIFF
--- a/packages/client/src/game/scenes/GameScene.ts
+++ b/packages/client/src/game/scenes/GameScene.ts
@@ -1466,19 +1466,24 @@ export class GameScene extends Phaser.Scene {
     const container = this.add.container(entity.pos.x, entity.pos.y);
     container.setDepth(entity.pos.y);
 
-    // Use the modular character pack for avatar variety: each entity gets a
-    // deterministic skin tint derived from its ID, falling back to the legacy
-    // players atlas when the character_pack texture is unavailable.
+    // Use the canonical Kenney players atlas for consistent avatar rendering.
+    // player-human for human entities, player-agent for AI agents.
+    // Falls back to the character_pack modular system when the players atlas
+    // is unavailable.
     let avatar: Phaser.GameObjects.GameObject;
-    if (this.textures.exists(CHARACTER_PACK_KEY)) {
+    if (this.textures.exists('players')) {
+      const frame = type === 'agent' ? 'player-agent' : 'player-human';
+      const sprite = this.add.sprite(0, 0, 'players', frame);
+      sprite.setOrigin(0.5, 0.5);
+      avatar = sprite;
+    } else if (this.textures.exists(CHARACTER_PACK_KEY)) {
       const tint = skinTintFromId(key);
       const assembledCharacter = createCharacter(this, tint, 0, 0);
       assembledCharacter.setPosition(0, -12);
       avatar = assembledCharacter;
     } else {
-      let frame = 'player-human';
-      if (type === 'agent') frame = 'player-agent';
-      const sprite = this.add.sprite(0, 0, 'players', frame);
+      const frame = type === 'agent' ? 'player-agent' : 'player-human';
+      const sprite = this.add.sprite(0, 0, 'characters', frame);
       sprite.setOrigin(0.5, 0.5);
       avatar = sprite;
     }
@@ -1555,17 +1560,12 @@ export class GameScene extends Phaser.Scene {
 
     let avatar: Phaser.GameObjects.GameObject;
     if (this.textures.getFrame('npcs', spriteKey)) {
+      // Primary: canonical Kenney NPC sprites with walk animations
       const sprite = this.add.sprite(0, 0, 'npcs', spriteKey);
       sprite.setOrigin(0.5, 0.5);
       avatar = sprite;
-    } else if (this.textures.exists(CHARACTER_PACK_KEY)) {
-      // NPC avatars fall back to the character pack with a deterministic tint
-      // from the NPC's definition ID.
-      const tint = skinTintFromId(npc.definitionId || key);
-      const assembledCharacter = createCharacter(this, tint, 0, 0);
-      assembledCharacter.setPosition(0, -12);
-      avatar = assembledCharacter;
     } else {
+      // Fallback: players atlas with green tint to distinguish NPC from player
       const sprite = this.add.sprite(0, 0, 'players', 'player-human');
       sprite.setOrigin(0.5, 0.5);
       sprite.setTint(0x66dd66);


### PR DESCRIPTION
## Summary
- Switch `addEntity()` to use canonical Kenney `players` atlas (`player-human`/`player-agent` frames) as primary renderer, instead of the `character_pack` modular system
- `character_pack` is now a fallback (only used if `players` atlas is unavailable)
- Remove `character_pack` as NPC fallback; NPCs now fall straight from `npcs` atlas to `players` (green-tinted)
- Walk animations continue to work via existing `updatePlayerAnimation()` logic (detects non-character_pack texture)

## Issue
Closes #526

## Root cause
`BootScene` loaded both `character_pack` and `players` atlases. `addEntity()` checked for `character_pack` first (always present), so the canonical `players` atlas (Kenney sprites with walk animations) was never used. The modular `character_pack` system assembled 5 body-part sprites at 0.09× scale, causing misalignment issues.

## Local CI
- [x] lint passed
- [x] format passed
- [x] typecheck passed
- [x] test passed (1196/1196)
- [x] build passed

## Test plan
- Connect to server, join a room
- Verify player/agent avatars show single-sprite Kenney characters (not multi-part modular)
- Verify NPC avatars still show role-specific Kenney sprites
- Verify walk animations play when entities move

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩토링**
  * 아바타 렌더링 시스템을 최적화하여 이미지 자산 선택 로직을 개선했습니다.
  * 누락된 자산에 대한 폴백 메커니즘을 강화하여 더욱 안정적이고 일관된 아바타 렌더링을 제공합니다.
  * 엔티티와 NPC 생성자의 아바타 생성 과정을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->