### PR TITLE
feat: auto-create GitHub issues from CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/code-scanning-to-issues.yml
+++ b/.github/workflows/code-scanning-to-issues.yml
@@ -1,0 +1,94 @@
+name: Code Scanning → GitHub Issues
+
+# Triggers when CodeQL finds a new alert or an existing alert appears in a branch.
+# Note: actionlint may warn about 'code_scanning_alert' — this is a known false positive
+# as actionlint's event database does not yet include this valid GitHub webhook event.
+# See: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#code_scanning_alert
+
+on:
+  code_scanning_alert:
+    types: [created, appeared_in_branch]
+
+permissions:
+  issues: write
+  security-events: read
+
+jobs:
+  create-issue:
+    name: Create issue for alert
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const alert = context.payload.alert;
+            const rule   = alert.rule;
+            const inst   = alert.most_recent_instance;
+            const loc    = inst.location;
+
+            const severityEmoji = {
+              critical: '🔴',
+              high:     '🟠',
+              medium:   '🟡',
+              low:      '🔵',
+              note:     '⚪',
+              warning:  '🟡',
+            }[rule.severity] ?? '⚪';
+
+            const lineRef = loc.end_line && loc.end_line !== loc.start_line
+              ? `${loc.start_line}-${loc.end_line}`
+              : `${loc.start_line}`;
+
+            const title = `[CodeQL] ${severityEmoji} ${rule.description} — ${loc.path}:${lineRef}`;
+
+            // Skip if an issue with this exact title already exists (de-duplicate)
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              state: 'open',
+              labels: 'codeql',
+              per_page: 100,
+            });
+            if (existing.data.some(i => i.title === title)) {
+              core.info(`Issue already exists for: ${title}`);
+              return;
+            }
+
+            const body = [
+              `## ${severityEmoji} Code Scanning Alert`,
+              '',
+              `| 항목 | 값 |`,
+              `|------|-----|`,
+              `| **Rule** | \`${rule.id}\` |`,
+              `| **Severity** | \`${rule.severity}\` |`,
+              `| **File** | \`${loc.path}\` (line ${lineRef}) |`,
+              `| **State** | \`${alert.state}\` |`,
+              `| **Alert URL** | [#${alert.number}](${alert.html_url}) |`,
+              '',
+              `### 설명`,
+              rule.full_description || rule.description,
+              '',
+              `### 재현 위치`,
+              '```',
+              `${loc.path}:${lineRef}`,
+              '```',
+              '',
+              `> 이 이슈는 CodeQL 코드 스캐닝 결과로 자동 생성되었습니다.`,
+              `> 해당 [CodeQL alert](${alert.html_url})를 직접 확인하려면 링크를 클릭하세요.`,
+            ].join('\n');
+
+            const labels = ['security', 'codeql'];
+            if (['critical', 'high'].includes(rule.severity)) {
+              labels.push('priority: high');
+            }
+
+            const { data: issue } = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              title,
+              body,
+              labels,
+            });
+
+            core.notice(`Created issue #${issue.number}: ${issue.html_url}`);


### PR DESCRIPTION
## Summary
- CodeQL 코드 스캐닝에서 새 alert가 발견될 때 자동으로 GitHub Issue를 생성합니다
- 중복 방지: 동일 제목의 open issue가 있으면 건너뜁니다
- severity에 따라 라벨 자동 적용 (`security`, `codeql`, `priority: high`)

## 동작 방식
- **트리거**: `code_scanning_alert` 웹훅 이벤트 (`created`, `appeared_in_branch`)
- **권한**: `issues: write`, `security-events: read`
- **Issue 내용**: rule ID, severity, 파일 위치, alert 직접 링크

## Issue 예시
```
[CodeQL] 🟠 SQL injection — src/db/query.ts:42
---
| Rule     | js/sql-injection |
| Severity | high             |
| File     | src/db/query.ts (line 42) |
| Alert URL | #123             |
```

## Local CI
- [x] actionlint: `code_scanning_alert`은 유효한 GitHub 이벤트이나 actionlint 데이터베이스 미등재 → false positive (CI에서 actionlint 미사용)
- [x] 워크플로우 YAML 문법 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* CodeQL 코드 스캔 경고에서 GitHub 이슈를 자동으로 생성하는 워크플로우가 추가되었습니다. 심각도에 따라 우선순위 라벨이 자동으로 적용되며, 중복 이슈 생성을 방지합니다. 보안 관련 코드 스캔 결과가 자동으로 추적됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->