### PR TITLE
fix(docker): restore compose startup on node:25-alpine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,3 +25,10 @@ packages/plugin
 .github
 !packages/client
 !packages/client/**
+!packages/plugin
+!packages/plugin/**
+packages/client/node_modules
+packages/client/**/node_modules
+packages/plugin/node_modules
+packages/plugin/**/node_modules
+!tests/package.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage
 FROM node:25-alpine AS builder
 
-RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+RUN npm install -g pnpm@9.0.0
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ RUN pnpm --filter @openclawworld/shared build && \
 # Production stage
 FROM node:25-alpine AS production
 
-RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+RUN npm install -g pnpm@9.0.0
 
 RUN apk add --no-cache wget && \
     addgroup -g 1001 -S nodejs && \

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,7 +1,7 @@
 FROM node:25-alpine
 
 RUN apk add --no-cache wget
-RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+RUN npm install -g pnpm@9.0.0
 
 # Create non-root user for security
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup


### PR DESCRIPTION
## Summary
- replace `corepack`-based pnpm activation with explicit `npm install -g pnpm@9.0.0` in server/client Dockerfiles for `node:25-alpine` compatibility
- prevent host workspace `node_modules` leakage from client/plugin paths in Docker build context to avoid stale symlinked Vite runtime paths
- keep `tests/package.json` and plugin/client workspace manifests available for lockfile-consistent installs

## Verification
- `docker compose -f docker-compose.yml up -d --build`
- `docker compose -f docker-compose.yml ps` shows `openclawworld-server` and `openclawworld-client` healthy
- `curl http://127.0.0.1:2567/health` returns ok
- `curl -I http://127.0.0.1:5173/` returns 200

Closes #553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker 이미지 빌드 설정을 업데이트했습니다.
  * 패키지 관리자 설치 방식을 개선하여 더 안정적인 빌드를 지원합니다.
  * 플러그인 패키지와 필요한 의존성이 빌드 프로세스에 올바르게 포함되도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->