### PR TITLE
fix: add health check retry and null-token guard (#565)

### DIFF
--- a/scripts/resident-agent-loop.ts
+++ b/scripts/resident-agent-loop.ts
@@ -3372,7 +3372,9 @@ class ResidentAgentLoop {
 
   private async checkServerHealth(): Promise<boolean> {
     try {
-      const response = await fetch(`${this.config.serverUrl}/health`);
+      const response = await fetch(`${this.config.serverUrl}/health`, {
+        signal: AbortSignal.timeout(5000),
+      });
       return response.ok;
     } catch {
       return false;
@@ -3389,6 +3391,7 @@ class ResidentAgentLoop {
         return true;
       }
       if (attempt < HEALTH_CHECK_MAX_RETRIES) {
+        // Backoff delays: 2s, 4s, 8s, 16s (no sleep after final attempt)
         const delayMs = HEALTH_CHECK_INITIAL_DELAY_MS * Math.pow(2, attempt - 1);
         console.warn(
           `⚠️ Server not reachable (attempt ${attempt}/${HEALTH_CHECK_MAX_RETRIES}). Retrying in ${delayMs}ms...`


### PR DESCRIPTION
## Summary
- Add retry with exponential backoff for server health check (5 retries, 2s/4s/8s/16s/32s) instead of single check-and-exit
- Validate agentId/sessionToken are non-empty after registration to prevent null tokens from leaking into observe/poll/move loop
- Abort loop startup if zero agents registered successfully, with clear error logging

## Issue
Closes #565

## Changes (single file: `scripts/resident-agent-loop.ts`)

| Fix | Description |
|-----|-------------|
| Health check retry | `waitForServerHealth()` with exponential backoff (5 retries) |
| Null token guard | Validate `agentId`/`sessionToken` in `register()` before accepting |
| Zero-agent guard | Abort in `run()` if `initializeAgents` produces 0 registered agents |

## Local CI
- [x] lint passed
- [x] format passed
- [x] build passed
- [x] typecheck passed
- [x] test passed (1196/1196)

## Test plan
- Start resident-agent-loop without server running → verify retry logs and clean exit after 5 attempts
- Start with server running but returning error on register → verify null-token guard prevents loop start
- Start normally → verify health check passes on first try and agents register

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 서버 헬스 체크에 자동 재시도(지수 백오프) 추가로 시작 안정성 향상
  * 헬스 체크 로그에 서버 URL 및 재시도 횟수 표시, 반복 실패 시 배포 이슈 보고
  * 등록 시 자격증명(agentId/sessionToken) 검증 강화 및 토큰 부분 가림 로그 처리
  * 초기화 후 등록된 에이전트가 없으면 오류 로깅 및 시작 중단 처리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->