### PR TITLE
fix: replace code_scanning_alert with workflow_run to fix phantom CI failures

### DIFF
--- a/.github/workflows/code-scanning-to-issues.yml
+++ b/.github/workflows/code-scanning-to-issues.yml
@@ -1,94 +1,130 @@
 name: Code Scanning → GitHub Issues
 
-# Triggers when CodeQL finds a new alert or an existing alert appears in a branch.
-# Note: actionlint may warn about 'code_scanning_alert' — this is a known false positive
-# as actionlint's event database does not yet include this valid GitHub webhook event.
-# See: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#code_scanning_alert
+# Triggers after CodeQL analysis completes on main branch.
+# Previously used `code_scanning_alert` event, which caused phantom failures
+# on every push because GitHub Actions validates all workflow files at push time
+# but cannot process webhook-only events during validation.
 
 on:
-  code_scanning_alert:
-    types: [created, appeared_in_branch]
+  workflow_run:
+    workflows: ['CodeQL']
+    types: [completed]
+    branches: [main]
 
 permissions:
   issues: write
   security-events: read
+  actions: read
 
 jobs:
-  create-issue:
-    name: Create issue for alert
+  create-issues:
+    name: Create issues for new alerts
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: Create GitHub Issue
+      - name: Fetch alerts and create issues
         uses: actions/github-script@v7
         with:
           script: |
-            const alert = context.payload.alert;
-            const rule   = alert.rule;
-            const inst   = alert.most_recent_instance;
-            const loc    = inst.location;
+            // Fetch open code scanning alerts for the default branch
+            let alerts;
+            try {
+              const resp = await github.rest.codeScanning.listAlertsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                ref: 'refs/heads/main',
+                per_page: 100,
+              });
+              alerts = resp.data;
+            } catch (error) {
+              if (error.status === 404) {
+                core.info('Code scanning not enabled or no alerts found.');
+                return;
+              }
+              throw error;
+            }
 
-            const severityEmoji = {
-              critical: '🔴',
-              high:     '🟠',
-              medium:   '🟡',
-              low:      '🔵',
-              note:     '⚪',
-              warning:  '🟡',
-            }[rule.severity] ?? '⚪';
+            if (alerts.length === 0) {
+              core.info('No open code scanning alerts.');
+              return;
+            }
 
-            const lineRef = loc.end_line && loc.end_line !== loc.start_line
-              ? `${loc.start_line}-${loc.end_line}`
-              : `${loc.start_line}`;
-
-            const title = `[CodeQL] ${severityEmoji} ${rule.description} — ${loc.path}:${lineRef}`;
-
-            // Skip if an issue with this exact title already exists (de-duplicate)
+            // Fetch existing open issues with 'codeql' label for deduplication
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
-              repo:  context.repo.repo,
+              repo: context.repo.repo,
               state: 'open',
               labels: 'codeql',
               per_page: 100,
             });
-            if (existing.data.some(i => i.title === title)) {
-              core.info(`Issue already exists for: ${title}`);
-              return;
+            const existingTitles = new Set(existing.data.map(i => i.title));
+
+            let created = 0;
+            for (const alert of alerts) {
+              const rule = alert.rule;
+              const inst = alert.most_recent_instance;
+              const loc = inst.location;
+
+              const severityEmoji = {
+                critical: '🔴',
+                high:     '🟠',
+                medium:   '🟡',
+                low:      '🔵',
+                note:     '⚪',
+                warning:  '🟡',
+              }[rule.severity] ?? '⚪';
+
+              const lineRef = loc.end_line && loc.end_line !== loc.start_line
+                ? `${loc.start_line}-${loc.end_line}`
+                : `${loc.start_line}`;
+
+              const title = `[CodeQL] ${severityEmoji} ${rule.description} — ${loc.path}:${lineRef}`;
+
+              if (existingTitles.has(title)) {
+                core.info(`Issue already exists: ${title}`);
+                continue;
+              }
+
+              const body = [
+                `## ${severityEmoji} Code Scanning Alert`,
+                '',
+                `| 항목 | 값 |`,
+                `|------|-----|`,
+                `| **Rule** | \`${rule.id}\` |`,
+                `| **Severity** | \`${rule.severity}\` |`,
+                `| **File** | \`${loc.path}\` (line ${lineRef}) |`,
+                `| **State** | \`${alert.state}\` |`,
+                `| **Alert URL** | [#${alert.number}](${alert.html_url}) |`,
+                '',
+                `### 설명`,
+                rule.full_description || rule.description,
+                '',
+                `### 재현 위치`,
+                '```',
+                `${loc.path}:${lineRef}`,
+                '```',
+                '',
+                `> 이 이슈는 CodeQL 코드 스캐닝 결과로 자동 생성되었습니다.`,
+                `> 해당 [CodeQL alert](${alert.html_url})를 직접 확인하려면 링크를 클릭하세요.`,
+              ].join('\n');
+
+              const labels = ['security', 'codeql'];
+              if (['critical', 'high'].includes(rule.severity)) {
+                labels.push('priority: high');
+              }
+
+              const { data: issue } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels,
+              });
+
+              existingTitles.add(title);
+              created++;
+              core.notice(`Created issue #${issue.number}: ${issue.html_url}`);
             }
 
-            const body = [
-              `## ${severityEmoji} Code Scanning Alert`,
-              '',
-              `| 항목 | 값 |`,
-              `|------|-----|`,
-              `| **Rule** | \`${rule.id}\` |`,
-              `| **Severity** | \`${rule.severity}\` |`,
-              `| **File** | \`${loc.path}\` (line ${lineRef}) |`,
-              `| **State** | \`${alert.state}\` |`,
-              `| **Alert URL** | [#${alert.number}](${alert.html_url}) |`,
-              '',
-              `### 설명`,
-              rule.full_description || rule.description,
-              '',
-              `### 재현 위치`,
-              '```',
-              `${loc.path}:${lineRef}`,
-              '```',
-              '',
-              `> 이 이슈는 CodeQL 코드 스캐닝 결과로 자동 생성되었습니다.`,
-              `> 해당 [CodeQL alert](${alert.html_url})를 직접 확인하려면 링크를 클릭하세요.`,
-            ].join('\n');
-
-            const labels = ['security', 'codeql'];
-            if (['critical', 'high'].includes(rule.severity)) {
-              labels.push('priority: high');
-            }
-
-            const { data: issue } = await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo:  context.repo.repo,
-              title,
-              body,
-              labels,
-            });
-
-            core.notice(`Created issue #${issue.number}: ${issue.html_url}`);
+            core.info(`Done. Created ${created} new issue(s) from ${alerts.length} open alert(s).`);


### PR DESCRIPTION
## Summary
- `code-scanning-to-issues.yml` 워크플로우가 `code_scanning_alert` 이벤트를 사용하여 **모든 push에서 100% 실패** (20+ 연속 실패)
- GitHub Actions는 push 시 모든 워크플로우 파일을 검증하지만 `code_scanning_alert`는 webhook 전용 이벤트라 검증 불가 → 0 jobs, 항상 failure
- `workflow_run` 이벤트로 전환: CodeQL 완료 후 code scanning API를 쿼리하여 동일 기능 유지

## Changes
| 변경 전 | 변경 후 |
|---------|---------|
| `on: code_scanning_alert` (webhook event) | `on: workflow_run` (CodeQL 완료 후) |
| `context.payload.alert` (webhook payload) | `codeScanning.listAlertsForRepo()` (API 쿼리) |
| 단일 alert 처리 | 모든 open alerts 일괄 처리 |

## Local CI
- [x] actionlint passed (all workflows)
- [x] lint passed
- [x] format:check passed

## Test plan
- PR 병합 후 다음 main push에서 `code-scanning-to-issues.yml`이 phantom failure를 생성하지 않는지 확인
- CodeQL 완료 후 `workflow_run`이 정상 트리거되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 코드 스캐닝 워크플로우가 개선되어 각 보안 경고에 대해 개별 이슈가 생성됩니다.
  * 중복된 이슈 제거 기능이 추가되었습니다.
  * 보안 경고의 심각도에 따른 우선순위 라벨이 자동으로 할당됩니다.
  * 경고 상세 정보와 위치 정보가 이슈 본문에 포함되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->