### PR TITLE
fix(security): resolve CodeQL alerts in resident-agent-loop.ts

### DIFF
--- a/scripts/resident-agent-loop.ts
+++ b/scripts/resident-agent-loop.ts
@@ -12,8 +12,8 @@
 
 import { randomBytes } from 'crypto';
 import { execFileSync, execSync } from 'child_process';
-import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
-import { homedir } from 'os';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync, unlinkSync, rmSync } from 'fs';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 
 // ============================================================================
@@ -293,25 +293,6 @@ const ROLES: AgentRole[] = [
   'chaos',
   'spammer',
 ];
-
-const ISSUE_AREAS = [
-  'Deploy',
-  'Sync',
-  'Movement',
-  'Collision',
-  'Chat',
-  'Social',
-  'NPC',
-  'Skills',
-  'Interactables',
-  'AIC',
-  'UI',
-  'Persistence',
-  'Performance',
-  'Docs',
-  'Behavior',
-  'Coverage',
-] as const;
 
 const EXPECTED_ENDPOINTS = [
   'register',
@@ -782,7 +763,6 @@ const ROLE_MISSIONS: Record<AgentRole, RoleMission[]> = {
 
 const STATE_DIR = join(homedir(), '.openclaw-resident-agent');
 const STATE_FILE = join(STATE_DIR, 'state.json');
-const ARTIFACTS_DIR = join(process.cwd(), 'artifacts', 'resident-agent');
 
 // ============================================================================
 // Utility Functions
@@ -854,11 +834,8 @@ function checkForUpdatesAndPull(): boolean {
 function restartProcess(): never {
   console.log('\n🔄 Restarting with updated code...\n');
   const args = process.argv.slice(1);
-  // Use execSync (already imported) to restart the process
-  // We use process.execPath (node/tsx) and pass all original arguments
-  execSync(`"${process.execPath}" ${args.map(a => `"${a}"`).join(' ')}`, {
+  execFileSync(process.execPath, args, {
     stdio: 'inherit',
-    shell: true,
   });
   process.exit(0);
 }
@@ -1041,9 +1018,9 @@ class GitHubIssueReporter {
     try {
       const labels = ['resident-agent', issue.area.toLowerCase(), issue.severity.toLowerCase()];
 
-      // Create issue body file if needed
-      const bodyFile = `/tmp/issue-body-${Date.now()}.md`;
-      writeFileSync(bodyFile, body);
+      const bodyDir = mkdtempSync(join(tmpdir(), 'issue-body-'));
+      const bodyFile = join(bodyDir, 'body.md');
+      writeFileSync(bodyFile, body, { mode: 0o600 });
 
       const result = execFileSync(
         'gh',
@@ -1051,9 +1028,9 @@ class GitHubIssueReporter {
         { encoding: 'utf-8' }
       );
 
-      // Clean up temp file
       try {
-        require('fs').unlinkSync(bodyFile);
+        unlinkSync(bodyFile);
+        rmSync(bodyDir, { recursive: true, force: true });
       } catch {}
 
       const issueUrl = result.trim();

--- a/scripts/resident-agent-loop.ts
+++ b/scripts/resident-agent-loop.ts
@@ -12,7 +12,15 @@
 
 import { randomBytes } from 'crypto';
 import { execFileSync, execSync } from 'child_process';
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync, unlinkSync, rmSync } from 'fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  unlinkSync,
+  rmSync,
+} from 'fs';
 import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 


### PR DESCRIPTION
## Summary

Resolves 4 CodeQL alerts on `scripts/resident-agent-loop.ts`:

- **#601** `js/indirect-command-line-injection` (CodeQL #56) → use `execFileSync(process.execPath, args, ...)` instead of `execSync('"' + process.execPath + '" ' + ..., { shell: true })`. Removes shell interpolation entirely.
- **#602** `js/insecure-temporary-file` (CodeQL #55) → use `mkdtempSync(join(tmpdir(), 'issue-body-'))` + `writeFileSync(..., { mode: 0o600 })`. Eliminates predictable `/tmp/issue-body-*` paths and tightens permissions.
- **#599** `js/unused-local-variable` (CodeQL #58) → remove unused `ARTIFACTS_DIR` constant.
- **#600** `js/unused-local-variable` (CodeQL #57) → remove unused `ISSUE_AREAS` constant.

## Test plan
- [x] `tsx --check scripts/resident-agent-loop.ts` passes
- [x] All other `execSync`/`execFileSync` call-sites untouched
- [x] `restartProcess()` semantics preserved (still spawns the same node binary with the same argv)
- [x] Temp file lifecycle: `unlinkSync` + `rmSync(dir, recursive)` cleanup retained

## Closes
Closes #599, #600, #601, #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 프로세스 재시작 메커니즘의 안정성 개선
  * GitHub 이슈 생성 시 임시 파일 처리의 보안 강화

* **Chores**
  * 미사용 상수 정리 및 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->