### PR TITLE
fix(security): use JSON.stringify for description escaping in plugin generator

### DIFF
--- a/packages/plugin/scripts/generate.ts
+++ b/packages/plugin/scripts/generate.ts
@@ -367,7 +367,7 @@ function generateManifestFile(tools: ToolMapping[]): string {
     lines.push(`    {`);
     lines.push(`      name: '${tool.toolName}',`);
     lines.push(`      required: ${required},`);
-    lines.push(`      description: '${(tool.summary || tool.description).replace(/'/g, "\\'")}',`);
+    lines.push(`      description: ${JSON.stringify(tool.summary || tool.description)},`);
     lines.push(`      sideEffects: '${sideEffects}',`);
     lines.push(`      defaultEnabled: ${defaultEnabled},`);
     lines.push(`      inputSchema: {`);


### PR DESCRIPTION
## Summary

Resolves CodeQL alert **#603** (`js/incomplete-sanitization`) on `packages/plugin/scripts/generate.ts:370`.

The previous `.replace(/'/g, "\\'")` only escaped single quotes — backslashes, newlines, and other meta-characters in `tool.summary`/`tool.description` could break out of the generated string literal. Replaced with `JSON.stringify(...)`, which emits a fully-escaped JS string literal regardless of the input.

## Test plan
- [x] `pnpm --filter @openclawworld/plugin generate` runs cleanly
- [x] `pnpm --filter @openclawworld/plugin typecheck` passes
- [x] After `pnpm exec prettier --write packages/plugin/src/generated/`, no diff vs the committed output (Codegen Freshness check should stay green)
- [x] Functional output unchanged for all current descriptions (which are plain ASCII)

## Closes
Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)