### PR TITLE
fix(ci): swap setup-node before pnpm/action-setup, drop version pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 9
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -63,16 +61,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 9
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -101,16 +97,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 9
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -158,16 +152,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 9
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -286,18 +278,16 @@ jobs:
             echo "✅ No map-impacting files changed"
           fi
 
-      - name: Setup pnpm
-        if: steps.check-map.outputs.map_changed == 'true'
-        uses: pnpm/action-setup@v6
-        with:
-          version: 9
-
       - name: Setup Node.js
         if: steps.check-map.outputs.map_changed == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      - name: Setup pnpm
+        if: steps.check-map.outputs.map_changed == 'true'
+        uses: pnpm/action-setup@v6
 
       - name: Cache node_modules
         if: steps.check-map.outputs.map_changed == 'true'
@@ -343,16 +333,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 9
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -384,16 +372,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 9
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -422,16 +408,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 9
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Cache node_modules
         uses: actions/cache@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,15 +31,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 9
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -34,16 +34,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 9
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -101,16 +99,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 9
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Cache node_modules
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary

Follow-up to #606. Pinning `version: 9` on pnpm/action-setup@v6 collides with the `packageManager: pnpm@9.0.0` field in package.json:

\`\`\`
Error: Multiple versions of pnpm specified:
  - version 9 in the GitHub Action config with the key \"version\"
  - version pnpm@9.0.0 in the package.json with the key \"packageManager\"
\`\`\`

This broke every CodeQL run on main since #606 landed (which is why open CodeQL alerts haven't auto-resolved despite the security fixes from #610/#611 being merged).

## Fix

- Move `Setup Node.js` before `Setup pnpm` in every job (ci.yml × 8, codeql.yml, load-test.yml × 2).
- Drop the explicit `version: 9` from action-setup blocks.

Once Node is installed first, corepack is on PATH and provides pnpm based on the `packageManager` field. action-setup v6 then runs against an already-available pnpm, with no npm bootstrap needed and no version conflict. setup-node's `cache: 'pnpm'` still works because corepack shims pnpm immediately after Node setup.

## Test plan
- [x] `gh run view` of the PR's CodeQL/CI runs should complete without the "Multiple versions of pnpm specified" error
- [x] Existing required checks (Codegen Freshness / Lint / Type Check / Build / Unit Tests / Map Consistency) keep passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)