### PR TITLE
fix(ci): drop setup-node's pnpm-store cache to fix self-hosted runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -65,7 +64,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -101,7 +99,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -156,7 +153,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -283,7 +279,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Setup pnpm
         if: steps.check-map.outputs.map_changed == 'true'
@@ -337,7 +332,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -376,7 +370,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -412,7 +405,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -103,7 +102,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6


### PR DESCRIPTION
## Summary

Follow-up to #627. After moving 'Setup Node.js' before 'Setup pnpm', every CI job fails in setup-node with:

\`\`\`
##[error]Unable to locate executable file: pnpm.
\`\`\`

setup-node@v6's \`cache: 'pnpm'\` invokes \`pnpm store path\` during the action — but pnpm isn't on PATH yet (it's installed by the next step), and the self-hosted runner doesn't auto-shim pnpm via corepack at that point. The cache lookup fails before Node setup completes, taking down every dependent job.

## Fix

Drop \`cache: 'pnpm'\` from every setup-node block. The repo already has a dedicated \`Cache node_modules\` step (actions/cache@v5 keyed on \`hashFiles('pnpm-lock.yaml')\`), which is the primary install cache; we only lose a secondary pnpm-store cache.

Applied to ci.yml (8 jobs) and load-test.yml (2 jobs).

## Test plan
- [x] Workflow YAML still parses
- [x] Existing \`Cache node_modules\` step preserved on every job
- [x] CI checks should now reach beyond Setup Node.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 자동화된 빌드 및 테스트 워크플로우에서 Node.js 설정 구성을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->