### PR TITLE
fix(ci): replace pnpm/action-setup with corepack to avoid broken-npm path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        run: |
+          corepack enable pnpm
+          corepack prepare pnpm@9.0.0 --activate
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -66,7 +70,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        run: |
+          corepack enable pnpm
+          corepack prepare pnpm@9.0.0 --activate
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -101,7 +109,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        run: |
+          corepack enable pnpm
+          corepack prepare pnpm@9.0.0 --activate
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -155,7 +167,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        run: |
+          corepack enable pnpm
+          corepack prepare pnpm@9.0.0 --activate
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -282,7 +298,11 @@ jobs:
 
       - name: Setup pnpm
         if: steps.check-map.outputs.map_changed == 'true'
-        uses: pnpm/action-setup@v6
+        run: |
+          corepack enable pnpm
+          corepack prepare pnpm@9.0.0 --activate
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
       - name: Cache node_modules
         if: steps.check-map.outputs.map_changed == 'true'
@@ -334,7 +354,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        run: |
+          corepack enable pnpm
+          corepack prepare pnpm@9.0.0 --activate
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -372,7 +396,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        run: |
+          corepack enable pnpm
+          corepack prepare pnpm@9.0.0 --activate
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -407,7 +435,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        run: |
+          corepack enable pnpm
+          corepack prepare pnpm@9.0.0 --activate
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
       - name: Cache node_modules
         uses: actions/cache@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,11 @@ jobs:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        run: |
+          corepack enable pnpm
+          corepack prepare pnpm@9.0.0 --activate
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -40,7 +40,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        run: |
+          corepack enable pnpm
+          corepack prepare pnpm@9.0.0 --activate
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -104,7 +108,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        run: |
+          corepack enable pnpm
+          corepack prepare pnpm@9.0.0 --activate
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
       - name: Cache node_modules
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary

The self-hosted runner has a broken Node 24 / npm install:

\`\`\`
Error: Cannot find module '../lib/cli.js'
Require stack:
- /home/barahime/actions-runner/externals.2.334.0/node24/bin/npm
\`\`\`

This kills every CI job at the 'Setup pnpm' step. The chain of attempts so far:

1. **#606**: bumped \`pnpm/action-setup\` v4 → v6 with \`version: 9\` → ran fine until…
2. **#627**: \`version: 9\` collided with \`packageManager: pnpm@9.0.0\` ("Multiple versions of pnpm specified"). Removed \`version\`, swapped step order.
3. **#628**: setup-node's \`cache: 'pnpm'\` then needed pnpm preinstalled. Removed the cache option.
4. Now action-setup@v6 (no version) tries to install pnpm via the runner's npm, which is itself broken.

## Fix

Bypass \`pnpm/action-setup\` entirely. Use **corepack** (bundled with Node) directly:

\`\`\`yaml
- name: Setup pnpm
  run: |
    corepack enable pnpm
    corepack prepare pnpm@9.0.0 --activate
  env:
    COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
\`\`\`

The pinned \`pnpm@9.0.0\` matches \`packageManager\` so local dev and CI stay aligned. \`COREPACK_ENABLE_DOWNLOAD_PROMPT=0\` keeps the first download non-interactive.

Applied to ci.yml (8 jobs), codeql.yml (1), load-test.yml (2).

## Test plan
- [x] YAML still parses
- [x] Existing \`Cache node_modules\` step preserved
- [x] CI should now reach \`pnpm install --frozen-lockfile\` and beyond

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* **CI/CD 인프라 업데이트**: 지속적 통합 및 배포 워크플로우에서 패키지 관리 설정을 개선했습니다. 린팅, 타입 체크, 테스트, 코드 생성, 맵 일관성 검증, OpenAPI 검증, 애플리케이션 빌드, API 퍼징 작업 및 로드 테스트를 포함한 모든 CI 파이프라인이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->